### PR TITLE
fix: add vertical scroll to code snippets on component docs

### DIFF
--- a/apps/web/components/ui/code-block.tsx
+++ b/apps/web/components/ui/code-block.tsx
@@ -43,7 +43,7 @@ export async function CodeBlock({
   return (
     <div
       className={clsx(
-        'group relative my-4 w-full bg-contrast-100 last:mb-0 only:my-0 md:my-5',
+        'group relative my-4 w-full overflow-y-scroll bg-contrast-100 last:mb-0 only:my-0 md:my-5',
         className
       )}
     >


### PR DESCRIPTION
Could not scroll vertically on code snippets. Added `overflow-scroll-y` to fix.

CleanShot 2024-10-08 at 15.21.55.mp4