### PR TITLE
docs: added top level types route

### DIFF
--- a/apps/web/vibes/soul/docs/types.mdx
+++ b/apps/web/vibes/soul/docs/types.mdx
@@ -1,0 +1,219 @@
+---
+title: 'Types'
+description: 'Types for the Soul Vibe'
+---
+
+## CartSummary
+
+```typescript
+interface CartSummary {
+  title?: string
+  caption?: string
+  subtotalLabel?: string
+  subtotal: string | Promise<string>
+  shippingLabel?: string
+  shipping?: string
+  taxLabel?: string
+  tax?: string | Promise<string>
+  grandTotalLabel?: string
+  grandTotal?: string | Promise<string>
+  ctaLabel?: string
+}
+```
+
+## CartProps
+
+```typescript
+interface CartProps {
+  title?: string
+  lineItems: CartLineItem[] | Promise<CartLineItem[]>
+  summary: CartSummary
+  emptyState: CartEmptyState
+  removeItemAriaLabel?: string
+  loadingAriaLabel?: string
+  removeLineItemAction(id: string): Promise<void>
+  decrementAriaLabel?: string
+  incrementAriaLabel?: string
+  updateLineItemQuantityAction({ id, quantity }: { id: string; quantity: number }): Promise<void>
+  redirectToCheckoutAction(): Promise<void>
+}
+```
+
+## CartLineItem
+
+```typescript
+interface CartLineItem {
+  id: string
+  image: Image
+  title: string
+  subtitle: string
+  quantity: number
+  price: string
+}
+```
+
+## CartEmptyState
+
+```typescript
+interface CartEmptyState {
+  title: string
+  subtitle: string
+  cta: {
+    label: string
+    href: string
+  }
+}
+```
+
+## Image
+
+```typescript
+interface Image {
+  alt: string
+  src: string
+}
+```
+
+## CheckboxGroupFilterOption
+
+```typescript
+interface CheckboxGroupFilterOption {
+  label: string
+  value: string
+}
+```
+
+## CheckboxGroupFilter
+
+```typescript
+interface CheckboxGroupFilter {
+  type: 'checkbox-group'
+  label: string
+  paramName: string
+  options: CheckboxGroupFilterOption[]
+}
+```
+
+## ToggleGroupFilter
+
+```typescript
+interface ToggleGroupFilter {
+  type: 'toggle-group'
+  label: string
+  paramName: string
+  options: { label: string; value: string }[]
+}
+```
+
+## RangeFilter
+
+```typescript
+interface RangeFilter {
+  type: 'range'
+  label: string
+  minParamName: string
+  maxParamName: string
+  min?: number
+  max?: number
+  minLabel?: string
+  maxLabel?: string
+  minPrepend?: React.ReactNode
+  maxPrepend?: React.ReactNode
+  minPlaceholder?: string
+  maxPlaceholder?: string
+}
+```
+
+## RatingFilter
+
+```typescript
+interface RatingFilter {
+  type: 'rating'
+  label: string
+  paramName: string
+}
+```
+
+## Option
+
+```typescript
+interface Option {
+  label: string
+  value: string
+}
+```
+
+## Filter
+
+```typescript
+type Filter = ToggleGroupFilter | RangeFilter | RatingFilter | CheckboxGroupFilter
+```
+
+## ProductCardProduct
+
+```typescript
+interface ProductCardProduct {
+  id: string
+  title: string
+  href: string
+  image?: Image
+  price?: ProductCardPrice
+  subtitle?: string
+  badge?: string
+  rating?: number
+}
+```
+
+## CompareCardProduct
+
+```typescript
+interface CompareCardProduct extends ProductCardProduct {
+  description?: string
+  availability?: string
+}
+```
+
+## ProductCardPriceRange
+
+```typescript
+interface ProductCardPriceRange {
+  type: 'range'
+  minValue: string
+  maxValue: string
+}
+```
+
+## ProductCardPrice
+
+```typescript
+type ProductCardPrice = string | ProductCardPriceRange | ProductCardSalePrice
+```
+
+## ProductCardSalePrice
+
+```typescript
+interface ProductCardSalePrice {
+  type: 'sale'
+  previousValue: string
+  currentValue: string
+}
+```
+
+## Pages
+
+```typescript
+interface Pages {
+  name: string
+  previousPage?: string
+  nextPage?: string
+}
+```
+
+## Breadcrumb
+
+```typescript
+interface Breadcrumb {
+  label: string
+  href: string
+}
+```

--- a/apps/web/vibes/soul/navigation.ts
+++ b/apps/web/vibes/soul/navigation.ts
@@ -263,4 +263,14 @@ export const navigation = [
       },
     ],
   },
+  {
+    title: 'API Reference',
+    pages: [
+      {
+        title: 'Types',
+        slug: 'types',
+        file: 'docs/types.mdx',
+      },
+    ],
+  },
 ] satisfies Navigation


### PR DESCRIPTION
We need a place reference types at the top-level. We can think link to each types header from other docs. This is a first attempt.