### PR TITLE
 feat: adds DatePicker form input

### DIFF
--- a/apps/web/vibes/soul/docs/form.mdx
+++ b/apps/web/vibes/soul/docs/form.mdx
@@ -1,0 +1,4 @@
+---
+title: Form
+preview: form-example
+---

--- a/apps/web/vibes/soul/examples/form.tsx
+++ b/apps/web/vibes/soul/examples/form.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Checkbox } from '../form/checkbox'
+import { DatePicker } from '../form/date-picker'
 import { Input } from '../form/input'
 import { Textarea } from '../form/textarea'
 import { ToggleGroup } from '../form/toggle-group'
@@ -27,6 +28,7 @@ export default function Preview() {
         errors={['This is required']}
       />
       <Checkbox id="consent" label="Consent" required />
+      <DatePicker required errors={['This is required']} />
     </div>
   )
 }

--- a/apps/web/vibes/soul/form/date-picker/index.tsx
+++ b/apps/web/vibes/soul/form/date-picker/index.tsx
@@ -1,0 +1,80 @@
+import { ComponentPropsWithoutRef, ElementRef, forwardRef, useState } from 'react'
+
+import * as PopoverPrimitive from '@radix-ui/react-popover'
+import { CalendarIcon } from 'lucide-react'
+
+import { Calendar } from '@/vibes/soul/primitives/calendar'
+
+import { Input } from '../input'
+
+interface Props extends Omit<ComponentPropsWithoutRef<'input'>, 'defaultValue' | 'onSelect'> {
+  defaultValue?: string | Date
+  disabledDays?: Date[]
+  errors?: string[]
+  onSelect?: (date: Date | undefined) => void
+  selected?: Date | undefined
+}
+
+const DatePicker = forwardRef<ElementRef<'input'>, Props>(
+  (
+    {
+      defaultValue,
+      disabledDays,
+      errors,
+      onSelect,
+      placeholder = 'MM/DD/YYYY',
+      required = false,
+      selected,
+      ...props
+    },
+    ref
+  ) => {
+    // State to manage the selected date
+    const [date, setDate] = useState<Date | undefined>(
+      defaultValue ? new Date(defaultValue) : undefined
+    )
+
+    // Format the selected date for display
+    const formattedSelected = selected ? Intl.DateTimeFormat().format(selected) : undefined
+
+    // Format the default date for display
+    const formattedDate = date ? Intl.DateTimeFormat().format(date) : undefined
+
+    return (
+      <PopoverPrimitive.Root>
+        <PopoverPrimitive.Trigger asChild>
+          <Input
+            errors={errors}
+            prepend={<CalendarIcon className="h-5 w-5" strokeWidth={1} />}
+            placeholder={placeholder}
+            readOnly={true}
+            ref={ref}
+            required={required}
+            type="text"
+            // We control the value of the input based on the selected date or the default date
+            value={formattedSelected ?? formattedDate ?? ''}
+            {...props}
+          />
+        </PopoverPrimitive.Trigger>
+        <PopoverPrimitive.Portal>
+          <PopoverPrimitive.Content
+            align="start"
+            className="z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+            sideOffset={8}
+          >
+            <Calendar
+              disabled={disabledDays}
+              mode="single"
+              onSelect={onSelect || setDate}
+              selected={selected ?? date}
+            />
+          </PopoverPrimitive.Content>
+        </PopoverPrimitive.Portal>
+      </PopoverPrimitive.Root>
+    )
+  }
+)
+
+DatePicker.displayName = 'DatePicker'
+
+export { DatePicker }

--- a/apps/web/vibes/soul/form/input/index.tsx
+++ b/apps/web/vibes/soul/form/input/index.tsx
@@ -39,7 +39,7 @@ export const Input = React.forwardRef<
           ref={ref}
           className={clsx(
             'placeholder-contrast-gray-500 w-full bg-transparent px-6 py-3 text-sm text-foreground [appearance:textfield] placeholder:font-normal focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
-            { 'py-2.5 pl-8 pr-4': prepend }
+            { 'py-2.5 pe-4 ps-12': prepend }
           )}
         />
       </div>

--- a/apps/web/vibes/soul/navigation.ts
+++ b/apps/web/vibes/soul/navigation.ts
@@ -269,4 +269,8 @@ export const navigation = [
       },
     ],
   },
+  {
+    title: 'Form',
+    pages: [{ title: 'Example', slug: 'form', file: 'docs/form.mdx' }],
+  },
 ] satisfies Navigation


### PR DESCRIPTION
> [!NOTE]
> Builds off https://github.com/makeswift/vibes/pull/250. Review last commit.

- Adds `DatePicker` form input that uses the `Calendar` and `Input` primitives. Supports `defaultValue` or controlled state. Single selection.
- Adds `Form` section in navigation (not sure if this is what we want).

![Screenshot 2024-10-28 at 3 12 53 PM](https://github.com/user-attachments/assets/cadcefd7-a9b0-45ca-9af8-fd524e8979e8)

![Screenshot 2024-10-28 at 3 13 45 PM](https://github.com/user-attachments/assets/f6822e2c-efef-41f3-aa8c-b6c718d41039)

