### PR TITLE
feat: adds SwatchPicker form input

### DIFF
--- a/apps/web/vibes/soul/form/swatch-picker/index.tsx
+++ b/apps/web/vibes/soul/form/swatch-picker/index.tsx
@@ -1,45 +1,67 @@
-'use client'
-
+import Image from 'next/image'
 import * as React from 'react'
 
-import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group'
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
 import clsx from 'clsx'
 
 import { ErrorMessage } from '@/vibes/soul/form/error-message'
 import { Label } from '@/vibes/soul/form/label'
 
-interface Option {
+interface SwatchColorOption {
   value: string
   label: string
-
+  color: string
   disabled?: boolean
 }
 
+interface SwatchImageOption {
+  value: string
+  label: string
+  image: { src: string }
+  disabled?: boolean
+}
+
+type Option = SwatchColorOption | SwatchImageOption
+
 export const SwatchPicker = React.forwardRef<
-  React.ElementRef<typeof ToggleGroupPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> & {
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & {
     label?: string
     options: Option[]
-    error?: string
+    errors?: string[]
   }
->(({ id, label, options, error, className, ...rest }, ref) => {
+>(({ id, label, options, errors, className, ...rest }, ref) => {
   return (
     <div className={clsx('space-y-2', className)}>
       {label !== undefined && label !== '' && <Label htmlFor={id}>{label}</Label>}
-      <ToggleGroupPrimitive.Root {...rest} ref={ref} aria-label={label} className="flex gap-2">
+      <RadioGroupPrimitive.Root {...rest} ref={ref} aria-label={label} className="flex gap-2">
         {options.map(option => (
-          <ToggleGroupPrimitive.Item
+          <RadioGroupPrimitive.Item
             key={option.value}
             value={option.value}
             aria-label={option.label}
             disabled={option.disabled}
-            className="whitespace-nowrap rounded-full border border-transparent px-3 py-2 font-body text-sm font-normal ring-primary transition-colors focus-visible:outline-0 focus-visible:ring-2 data-[disabled]:cursor-not-allowed data-[state=off]:bg-contrast-100 data-[state=on]:bg-foreground data-[state=on]:text-background data-[disabled]:opacity-50 data-[disabled]:hover:border-transparent data-[state=off]:hover:border-contrast-300"
+            className={clsx(
+              'box-content h-10 w-10 rounded-full border p-1 transition-colors hover:border-contrast-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-20 disabled:hover:border-transparent data-[state=checked]:border-foreground',
+              errors && errors.length > 0
+                ? 'border-error disabled:border-transparent'
+                : 'border-transparent'
+            )}
           >
-            {option.label}
-          </ToggleGroupPrimitive.Item>
+            {'color' in option ? (
+              <span
+                className="block h-10 w-10 rounded-full border border-foreground/10"
+                style={{ backgroundColor: option.color }}
+              />
+            ) : (
+              <span className="relative block h-10 w-10 rounded-full border border-foreground/10">
+                <Image src={option.image.src} alt={option.label} height={40} width={40} />
+              </span>
+            )}
+          </RadioGroupPrimitive.Item>
         ))}
-      </ToggleGroupPrimitive.Root>
-      {error !== undefined && error !== '' && <ErrorMessage>{error}</ErrorMessage>}
+      </RadioGroupPrimitive.Root>
+      {errors?.map(error => <ErrorMessage key={error}>{error}</ErrorMessage>)}
     </div>
   )
 })


### PR DESCRIPTION
+ Updates SwatchPicker to accept options with hex color or image.
+ Uses  Radix's `RadioGroup` to append input elements inside forms.
+ Modifies styles to match designs.
+ Fixes errors prop and styles.

![Screenshot 2024-10-29 at 3 09 02 PM](https://github.com/user-attachments/assets/f61cbab8-649f-4057-912a-f6815f3cdcb2)
