### PR TITLE
feat: add missing searchHref prop in Navigation

### DIFF
--- a/apps/web/vibes/soul/examples/pages/blog/index.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/index.tsx
@@ -67,6 +67,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <FeaturedBlogPostList

--- a/apps/web/vibes/soul/examples/pages/blog/post/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/post/electric.tsx
@@ -73,6 +73,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <BlogPostContent

--- a/apps/web/vibes/soul/examples/pages/blog/post/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/post/luxury.tsx
@@ -73,6 +73,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <BlogPostContent

--- a/apps/web/vibes/soul/examples/pages/blog/post/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/post/warm.tsx
@@ -73,6 +73,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <BlogPostContent

--- a/apps/web/vibes/soul/examples/pages/home/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/home/electric.tsx
@@ -205,6 +205,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
       <Slideshow slides={heroSlides} />
       <FeaturedCardCarousel title="Categories" cards={cards} />

--- a/apps/web/vibes/soul/examples/pages/home/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/home/luxury.tsx
@@ -89,6 +89,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
       <Slideshow slides={heroSlides} />
       <FeaturedCardCarousel title="Categories" cards={cards} />

--- a/apps/web/vibes/soul/examples/pages/home/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/home/warm.tsx
@@ -97,6 +97,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
       <Slideshow slides={heroSlides} />
       <FeaturedCardCarousel title="Categories" cards={cards} />

--- a/apps/web/vibes/soul/examples/pages/not-found/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/not-found/electric.tsx
@@ -181,6 +181,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <NotFound />

--- a/apps/web/vibes/soul/examples/pages/not-found/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/not-found/luxury.tsx
@@ -157,6 +157,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <NotFound />

--- a/apps/web/vibes/soul/examples/pages/not-found/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/not-found/warm.tsx
@@ -161,6 +161,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <NotFound />

--- a/apps/web/vibes/soul/examples/pages/product/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/product/electric.tsx
@@ -40,6 +40,7 @@ export default function Preview() {
           accountHref="#"
           activeLocale="EN"
           locales={locales}
+          searchHref="#"
         />
 
         <ProductDetail product={product} />

--- a/apps/web/vibes/soul/examples/pages/product/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/product/luxury.tsx
@@ -41,6 +41,7 @@ export default function Preview() {
           accountHref="#"
           activeLocale="EN"
           locales={locales}
+          searchHref="#"
         />
 
         <ProductDetail product={product} />

--- a/apps/web/vibes/soul/examples/pages/product/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/product/warm.tsx
@@ -41,6 +41,7 @@ export default function Preview() {
           accountHref="#"
           activeLocale="EN"
           locales={locales}
+          searchHref="#"
         />
 
         <ProductDetail product={product} />

--- a/apps/web/vibes/soul/examples/pages/products/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/products/electric.tsx
@@ -33,6 +33,7 @@ export default function Preview() {
         accountHref="#"
         activeLocale="EN"
         locales={locales}
+        searchHref="#"
       />
       <ProductsListSection
         breadcrumbs={breadcrumbs}

--- a/apps/web/vibes/soul/examples/pages/products/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/products/luxury.tsx
@@ -33,6 +33,7 @@ export default function Preview() {
         accountHref="#"
         activeLocale="EN"
         locales={locales}
+        searchHref="#"
       />
       <ProductsListSection
         breadcrumbs={breadcrumbs}

--- a/apps/web/vibes/soul/examples/pages/products/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/products/warm.tsx
@@ -33,6 +33,7 @@ export default function Preview() {
         accountHref="#"
         activeLocale="EN"
         locales={locales}
+        searchHref="#"
       />
       <ProductsListSection
         breadcrumbs={breadcrumbs}

--- a/apps/web/vibes/soul/examples/primitives/navigation/electric.tsx
+++ b/apps/web/vibes/soul/examples/primitives/navigation/electric.tsx
@@ -121,6 +121,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
     </div>
   )

--- a/apps/web/vibes/soul/examples/primitives/navigation/luxury.tsx
+++ b/apps/web/vibes/soul/examples/primitives/navigation/luxury.tsx
@@ -92,6 +92,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
     </div>
   )

--- a/apps/web/vibes/soul/examples/primitives/navigation/warm.tsx
+++ b/apps/web/vibes/soul/examples/primitives/navigation/warm.tsx
@@ -94,6 +94,7 @@ export default function Preview() {
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
     </div>
   )

--- a/apps/web/vibes/soul/pages/cart/index.tsx
+++ b/apps/web/vibes/soul/pages/cart/index.tsx
@@ -91,6 +91,7 @@ export const CartPage = function CartPage({
         accountHref="#"
         locales={locales}
         activeLocale="EN"
+        searchHref="#"
       />
 
       <Cart

--- a/apps/web/vibes/soul/primitives/navigation/index.tsx
+++ b/apps/web/vibes/soul/primitives/navigation/index.tsx
@@ -48,6 +48,7 @@ interface Props {
   locales?: { id: string; region: string; language: string }[]
   logo?: string | Image
   searchHref: string
+  searchParamName?: string
 }
 
 export const Navigation = forwardRef(function Navigation(
@@ -60,6 +61,7 @@ export const Navigation = forwardRef(function Navigation(
     locales,
     logo,
     searchHref,
+    searchParamName = 'term',
     ...rest
   }: Props,
   ref: Ref<HTMLDivElement>
@@ -160,7 +162,7 @@ export const Navigation = forwardRef(function Navigation(
     const searchTerm = searchInputRef.current?.value.trim() ?? ''
 
     if (searchTerm.length > 0) {
-      router.push(`${searchHref}?term=${encodeURIComponent(searchTerm)}`)
+      router.push(`${searchHref}?${searchParamName}=${encodeURIComponent(searchTerm)}`)
     }
   }
 

--- a/apps/web/vibes/soul/primitives/navigation/index.tsx
+++ b/apps/web/vibes/soul/primitives/navigation/index.tsx
@@ -47,7 +47,7 @@ interface Props {
   links: Links[]
   locales?: { id: string; region: string; language: string }[]
   logo?: string | Image
-  searchHref?: string
+  searchHref: string
 }
 
 export const Navigation = forwardRef(function Navigation(
@@ -59,7 +59,7 @@ export const Navigation = forwardRef(function Navigation(
     links,
     locales,
     logo,
-    searchHref = '/search',
+    searchHref,
     ...rest
   }: Props,
   ref: Ref<HTMLDivElement>

--- a/apps/web/vibes/soul/primitives/navigation/index.tsx
+++ b/apps/web/vibes/soul/primitives/navigation/index.tsx
@@ -39,18 +39,29 @@ export interface Links {
 }
 
 interface Props {
-  cartHref: string
-  cartCount?: number
-  accountHref: string
-  links: Links[]
   // searchAction: (query: string) => Promise<SerializableProduct[]>
-  logo?: string | Image
+  accountHref: string
   activeLocale?: string
+  cartCount?: number
+  cartHref: string
+  links: Links[]
   locales?: { id: string; region: string; language: string }[]
+  logo?: string | Image
+  searchHref: string
 }
 
 export const Navigation = forwardRef(function Navigation(
-  { cartHref, cartCount, accountHref, links, logo, activeLocale, locales, ...rest }: Props,
+  {
+    accountHref,
+    activeLocale,
+    cartCount,
+    cartHref,
+    links,
+    locales,
+    logo,
+    searchHref,
+    ...rest
+  }: Props,
   ref: Ref<HTMLDivElement>
 ) {
   const [navOpen, setNavOpen] = useState(false)
@@ -149,7 +160,7 @@ export const Navigation = forwardRef(function Navigation(
     const searchTerm = searchInputRef.current?.value.trim() ?? ''
 
     if (searchTerm.length > 0) {
-      router.push(`/search?term=${encodeURIComponent(searchTerm)}`)
+      router.push(`/${searchHref}?term=${encodeURIComponent(searchTerm)}`)
     }
   }
 

--- a/apps/web/vibes/soul/primitives/navigation/index.tsx
+++ b/apps/web/vibes/soul/primitives/navigation/index.tsx
@@ -160,7 +160,7 @@ export const Navigation = forwardRef(function Navigation(
     const searchTerm = searchInputRef.current?.value.trim() ?? ''
 
     if (searchTerm.length > 0) {
-      router.push(`/${searchHref}?term=${encodeURIComponent(searchTerm)}`)
+      router.push(`${searchHref}?term=${encodeURIComponent(searchTerm)}`)
     }
   }
 

--- a/apps/web/vibes/soul/primitives/navigation/index.tsx
+++ b/apps/web/vibes/soul/primitives/navigation/index.tsx
@@ -47,7 +47,7 @@ interface Props {
   links: Links[]
   locales?: { id: string; region: string; language: string }[]
   logo?: string | Image
-  searchHref: string
+  searchHref?: string
 }
 
 export const Navigation = forwardRef(function Navigation(
@@ -59,7 +59,7 @@ export const Navigation = forwardRef(function Navigation(
     links,
     locales,
     logo,
-    searchHref,
+    searchHref = '/search',
     ...rest
   }: Props,
   ref: Ref<HTMLDivElement>


### PR DESCRIPTION
Just like `accountHref` and `cartHref`, we need to allow passing in a custom search href the form submits too. 