### PR TITLE
fix(Banner): allow `children` to be a `<p>` or another `<div>`

### DIFF
--- a/apps/web/vibes/soul/primitives/banner/index.tsx
+++ b/apps/web/vibes/soul/primitives/banner/index.tsx
@@ -40,9 +40,9 @@ export const Banner = forwardRef<React.ComponentRef<'div'>, Props>(
         id="announcement-bar"
         ref={ref}
       >
-        <p className="p-3 pr-12 text-sm text-foreground @xl:px-12 @xl:text-center @xl:text-base">
+        <div className="p-3 pr-12 text-sm text-foreground @xl:px-12 @xl:text-center @xl:text-base">
           {children}
-        </p>
+        </div>
 
         {!hideDismiss && (
           <button


### PR DESCRIPTION
HTML spec disallows nesting `<p>`s and `<div>`s inside of a `<p>`.