### PR TITLE
fix: trigger server render on sort

### DIFF
--- a/apps/web/vibes/soul/sections/products-list-section/sorting.tsx
+++ b/apps/web/vibes/soul/sections/products-list-section/sorting.tsx
@@ -27,7 +27,10 @@ export function Sorting({ label = 'Sort', options, paramName }: Props) {
 }
 
 function SortingInner({ label = 'Sort', options, paramName = 'sort', defaultValue = '' }: Props) {
-  const [param, setParam] = useQueryState(paramName, parseAsString.withDefault(defaultValue))
+  const [param, setParam] = useQueryState(
+    paramName,
+    parseAsString.withDefault(defaultValue).withOptions({ shallow: false })
+  )
   const resolved = options instanceof Promise ? use(options) : options
 
   return (


### PR DESCRIPTION
Fixes issue of changing sort param no retriggering server render by passing in `shallow: false` as an option.