### PR TITLE
fix: add z-index to select to prevent it from being hidden

### DIFF
--- a/apps/web/vibes/soul/form/select/index.tsx
+++ b/apps/web/vibes/soul/form/select/index.tsx
@@ -56,7 +56,7 @@ export function Select({
           </SelectPrimitive.Icon>
         </SelectPrimitive.Trigger>
         <SelectPrimitive.Portal>
-          <SelectPrimitive.Content className="max-h-80 w-full overflow-y-scroll rounded-xl bg-background p-2 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 @4xl:rounded-3xl @4xl:p-4">
+          <SelectPrimitive.Content className="z-50 max-h-80 w-full overflow-y-scroll rounded-xl bg-background p-2 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 @4xl:rounded-3xl @4xl:p-4">
             <SelectPrimitive.ScrollUpButton className="flex w-full cursor-default items-center justify-center py-3">
               <ChevronUp strokeWidth={1.5} className="w-5 text-foreground" />
             </SelectPrimitive.ScrollUpButton>


### PR DESCRIPTION
Sets a z-index to prevent select from being hidden by other elements.

Before:

https://github.com/user-attachments/assets/b1db962f-b8b9-455c-9123-3bec2100839c

After:

https://github.com/user-attachments/assets/ca1177e3-4eec-4b43-8c16-acbab613d1b3