### PR TITLE
fix: cursor navigation by remove unused param

### DIFF
--- a/apps/web/vibes/soul/primitives/cursor-pagination/index.tsx
+++ b/apps/web/vibes/soul/primitives/cursor-pagination/index.tsx
@@ -43,7 +43,12 @@ function CursorPaginationResolved({ info }: Props) {
   return (
     <div className="flex w-full items-center justify-center gap-3 py-10">
       {startCursor != null ? (
-        <PaginationLink href={serialize(searchParams, { [startCursorParamName]: startCursor })}>
+        <PaginationLink
+          href={serialize(searchParams, {
+            [startCursorParamName]: startCursor,
+            [endCursorParamName]: null,
+          })}
+        >
           <ArrowLeft size={24} strokeWidth={1} />
         </PaginationLink>
       ) : (
@@ -52,7 +57,12 @@ function CursorPaginationResolved({ info }: Props) {
         </SkeletonLink>
       )}
       {endCursor != null ? (
-        <PaginationLink href={serialize(searchParams, { [endCursorParamName]: endCursor })}>
+        <PaginationLink
+          href={serialize(searchParams, {
+            [endCursorParamName]: endCursor,
+            [startCursorParamName]: null,
+          })}
+        >
           <ArrowRight size={24} strokeWidth={1} />
         </PaginationLink>
       ) : (


### PR DESCRIPTION
## What/Why?
For cursor navigation we either want an `after` or `before`, not both.

Before:

https://github.com/user-attachments/assets/e7189cd1-ebbf-47df-8197-211073c94ed5

After:

https://github.com/user-attachments/assets/1a76128f-846a-418e-913d-368e724c8254