### PR TITLE
feat: add streamable props in Reviews section

### DIFF
--- a/apps/web/vibes/soul/sections/reviews/index.tsx
+++ b/apps/web/vibes/soul/sections/reviews/index.tsx
@@ -31,9 +31,10 @@ async function ReviewsImpl({
   emptyStateMessage,
   reviewsLabel = 'Reviews',
 }: Readonly<Props>) {
-  const reviews = await mapStreamable(streamableReviews, resolvedReviews => resolvedReviews)
+  const reviews = await streamableReviews
 
-  if (reviews.length === 0) return <ReviewsEmptyState message={emptyStateMessage} />
+  if (reviews.length === 0)
+    return <ReviewsEmptyState message={emptyStateMessage} reviewsLabel={reviewsLabel} />
 
   return (
     <StickySidebarLayout
@@ -156,7 +157,7 @@ export function ReviewsSkeleton({ reviewsLabel = 'Reviews' }: { reviewsLabel?: s
 
 export function Reviews({ reviewsLabel = 'Reviews', ...props }: Props) {
   return (
-    <Suspense fallback={<ReviewsSkeleton />}>
+    <Suspense fallback={<ReviewsSkeleton reviewsLabel={reviewsLabel} />}>
       <ReviewsImpl {...props} reviewsLabel={reviewsLabel} />
     </Suspense>
   )


### PR DESCRIPTION
- Wraps `<Reviews />` in `Suspense` boundary and internally resolves Promises if passed.
- Streams in data inside components for total count and average rating.
- Adds missing `reviewsLabel`.