### PR TITLE
fix: slide not in view when element inside is focused

### DIFF
--- a/apps/web/vibes/soul/sections/slideshow/index.tsx
+++ b/apps/web/vibes/soul/sections/slideshow/index.tsx
@@ -113,16 +113,14 @@ export function Slideshow({ slides, interval = 5000, className }: Props) {
   }, [emblaApi, playCount])
 
   return (
-    <section
-      className={clsx('relative h-[80vh] overflow-hidden bg-primary-shadow @container', className)}
-    >
-      <div ref={emblaRef} className="h-full">
+    <section className={clsx('relative h-[80vh] bg-primary-shadow @container', className)}>
+      <div ref={emblaRef} className="h-full overflow-hidden">
         <div className="flex h-full">
           {slides.map(({ title, description, image, cta }, idx) => {
             return (
               <div key={idx} className="relative h-full w-full min-w-0 shrink-0 grow-0 basis-full">
                 <div className="absolute inset-x-0 bottom-0 z-10 bg-gradient-to-t from-foreground/80 to-transparent">
-                  <div className="mx-auto w-full max-w-screen-2xl px-4 pb-16 pt-12 text-background @xl:px-6 @xl:pb-20 @xl:pt-16 @4xl:px-8 @4xl:pt-20">
+                  <div className="mx-auto w-full max-w-screen-2xl text-balance px-4 pb-16 pt-12 text-background @xl:px-6 @xl:pb-20 @xl:pt-16 @4xl:px-8 @4xl:pt-20">
                     <h1 className="m-0 max-w-xl font-heading text-4xl font-medium leading-none @2xl:text-5xl @2xl:leading-[.9] @4xl:text-6xl">
                       {title}
                     </h1>


### PR DESCRIPTION
## What/Why?

- Fixes issue where the slide was not visible when the button was focused
- Replaces `text-pretty` with `text-balance` for text-wrapping

## Testing

https://github.com/user-attachments/assets/96060633-40b8-4585-8572-5d4d0019c6f1