### PR TITLE
Fix Sitemap and Algolia Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ out/
 build
 dist
 sitemap*.xml
+robots.txt
 
 # Debug
 npm-debug.log*

--- a/apps/web/components/navigation/header.tsx
+++ b/apps/web/components/navigation/header.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image'
 import '@docsearch/css'
 
 import { ModeToggle } from '@/components/ui/mode-toggle'
+import { env } from '@/lib/env'
 
 import { ChapterSelect } from './chapter-select'
 import { GroupLink } from './group-link'
@@ -65,9 +66,9 @@ export function Header({ chapters, chapterSlug }: Props) {
           </Button> */}
 
           <DocSearch
-            appId="Q9L04M9AMF"
-            indexName="vibes"
-            apiKey="931574c95fe03313ea73bd5a77286fee"
+            appId={env.NEXT_PUBLIC_ALGOLIA_APP_ID}
+            indexName={env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME}
+            apiKey={env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY}
           />
 
           <ModeToggle />

--- a/apps/web/components/navigation/header.tsx
+++ b/apps/web/components/navigation/header.tsx
@@ -67,7 +67,7 @@ export function Header({ chapters, chapterSlug }: Props) {
           <DocSearch
             appId="Q9L04M9AMF"
             indexName="vibes"
-            apiKey="ef510190238e6bf2ae942046fd83e4b9"
+            apiKey="931574c95fe03313ea73bd5a77286fee"
           />
 
           <ModeToggle />

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -11,9 +11,15 @@ export const env = createEnv({
   },
   client: {
     NEXT_PUBLIC_POSTHOG_KEY: z.string(),
+    NEXT_PUBLIC_ALGOLIA_APP_ID: z.string(),
+    NEXT_PUBLIC_ALGOLIA_INDEX_NAME: z.string(),
+    NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: z.string(),
   },
   experimental__runtimeEnv: {
     NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
+    NEXT_PUBLIC_ALGOLIA_APP_ID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID,
+    NEXT_PUBLIC_ALGOLIA_INDEX_NAME: process.env.NEXT_PUBLIC_ALGOLIA_INDEX_NAME,
+    NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY: process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY,
   },
   skipValidation: process.env.npm_lifecycle_event === 'lint',
 })

--- a/apps/web/next-sitemap.config.js
+++ b/apps/web/next-sitemap.config.js
@@ -1,9 +1,9 @@
 /** @type {import('next-sitemap').IConfig} */
 
-const dev = process.env.NODE_ENV !== 'production'
+const siteUrl = process.env.VERCEL_URL || 'localhost:3000'
 
 module.exports = {
-  siteUrl: dev ? 'http://localhost:3000' : 'https://vibes.site/',
+  siteUrl,
   generateRobotsTxt: true,
   transform: async (config, path) => {
     // ignore preview pages

--- a/apps/web/next-sitemap.config.js
+++ b/apps/web/next-sitemap.config.js
@@ -5,4 +5,20 @@ const dev = process.env.NODE_ENV !== 'production'
 module.exports = {
   siteUrl: dev ? 'http://localhost:3000' : 'https://vibes.site/',
   generateRobotsTxt: true,
+  transform: async (config, path) => {
+    // ignore preview pages
+    if (path.includes('/preview/')) {
+      console.log('ignoring path', path)
+      return null
+    }
+
+    // Use default transformation for all other cases
+    return {
+      loc: path,
+      changefreq: config.changefreq,
+      priority: config.priority,
+      lastmod: config.autoLastmod ? new Date().toISOString() : undefined,
+      alternateRefs: config.alternateRefs ?? [],
+    }
+  },
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,11 +5,11 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev --turbo",
-    "build": "next build",
+    "build": "next build && pnpm sitemap",
     "start": "next start",
     "lint": "next lint",
     "icons": "npx @svgr/cli --no-runtime-config --typescript --replace-attr-values \"#64de21=currentColor\" --out-dir icons/generated -- icons/svg && npx prettier icons/generated --write",
-    "postbuild": "next-sitemap",
+    "sitemap": "next-sitemap",
     "vibes": "node scripts/build-preview-index.js ./components/vibes",
     "typecheck": "tsc"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,11 +5,10 @@
   "license": "MIT",
   "scripts": {
     "dev": "next dev --turbo",
-    "build": "next build && pnpm sitemap",
+    "build": "next build &&  next-sitemap",
     "start": "next start",
     "lint": "next lint",
     "icons": "npx @svgr/cli --no-runtime-config --typescript --replace-attr-values \"#64de21=currentColor\" --out-dir icons/generated -- icons/svg && npx prettier icons/generated --write",
-    "sitemap": "next-sitemap",
     "vibes": "node scripts/build-preview-index.js ./components/vibes",
     "typecheck": "tsc"
   },


### PR DESCRIPTION
- update sitemap to ignore paths with `/preview`
- remove write API key for algolia and use read only key
- ignore `robots.txt` so it is generated on build
- update package.json `build` script to also call `sitemap` script (wasn't be called automatically in `postbuild` script)
- reference `VERCEL_URL` environment variable instead of hard-coded vibes.site url - this will allow us to test crawlers on preview deploy links if we want to