### PR TITLE
feat: add Toaster primitive for Soul

### DIFF
--- a/apps/web/app/(preview)/layout.tsx
+++ b/apps/web/app/(preview)/layout.tsx
@@ -1,5 +1,7 @@
-import { ZoomListener } from '../zoom-listener';
 import './style/globals.css';
+import { Toaster } from '@/vibes/soul/primitives/toaster';
+
+import { ZoomListener } from '../zoom-listener';
 
 export const metadata = {
   title: 'Vibes preview',
@@ -10,7 +12,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <ZoomListener />
-      <body>{children}</body>
+
+      <body>
+        <Toaster closeButton={true} position="top-right" />
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/web/app/(preview)/layout.tsx
+++ b/apps/web/app/(preview)/layout.tsx
@@ -14,6 +14,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <ZoomListener />
 
       <body>
+        {/* TODO: This is currently hardcoded to the Soul vibe. 
+        We want to make it so that each vibe has its own preview 
+        layout. */}
         <Toaster position="top-right" />
         {children}
       </body>

--- a/apps/web/app/(preview)/layout.tsx
+++ b/apps/web/app/(preview)/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <ZoomListener />
 
       <body>
-        <Toaster closeButton={true} position="top-right" />
+        <Toaster position="top-right" />
         {children}
       </body>
     </html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -80,6 +80,7 @@
     "remark-mdx-frontmatter": "^4.0.0",
     "resend": "^3.2.0",
     "server-only": "^0.0.1",
+    "sonner": "^1.7.0",
     "tailwind-merge": "^2.2.1",
     "utils": "link:@/lib/utils",
     "zod": "^3.23.8"

--- a/apps/web/vibes/soul/docs/toaster.mdx
+++ b/apps/web/vibes/soul/docs/toaster.mdx
@@ -1,0 +1,5 @@
+---
+title: Toaster 
+preview: toaster-example
+previewSize: sm
+---

--- a/apps/web/vibes/soul/examples.ts
+++ b/apps/web/vibes/soul/examples.ts
@@ -840,4 +840,11 @@ export const examples = [
     files: ['examples/primitives/textarea/index.tsx'],
     component: lazy(() => import('./examples/primitives/textarea')),
   },
+  {
+    name: 'toaster-example',
+    dependencies: [],
+    registryDependencies: ['toaster'],
+    files: ['examples/primitives/toaster/index.tsx'],
+    component: lazy(() => import('./examples/primitives/toaster')),
+  },
 ] satisfies Components;

--- a/apps/web/vibes/soul/examples/primitives/alert/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/alert/index.tsx
@@ -8,6 +8,7 @@ export default function Preview() {
       <Alert message="This is a success alert" variant="success" />
       <Alert message="This is a warning alert" variant="warning" />
       <Alert message="This is an error alert" variant="error" />
+      <Alert message="This is an info alert" variant="info" />
     </div>
   );
 }

--- a/apps/web/vibes/soul/examples/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/toaster/index.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { toast } from 'sonner'
-
 import { Button } from '@/vibes/soul/primitives/button'
+import { toast } from '@/vibes/soul/primitives/toaster'
 
 export default function Preview() {
   return (
@@ -21,6 +20,18 @@ export default function Preview() {
 
       <Button variant="primary" onClick={() => toast.info('Info')}>
         Info
+      </Button>
+
+      <Button
+        variant="primary"
+        onClick={() =>
+          toast.success('Success', {
+            description: 'Description of toast',
+            action: { label: 'Undo', onClick: () => console.log('undo') },
+          })
+        }
+      >
+        Options
       </Button>
     </div>
   )

--- a/apps/web/vibes/soul/examples/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/toaster/index.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { toast } from 'sonner'
+
+import { Button } from '@/vibes/soul/primitives/button'
+
+export default function Preview() {
+  return (
+    <div className="grid h-screen place-content-center gap-x-4 gap-y-6">
+      <Button variant="primary" onClick={() => toast.success('Success')}>
+        Success
+      </Button>
+
+      <Button variant="primary" onClick={() => toast.error('Error')}>
+        Error
+      </Button>
+
+      <Button variant="primary" onClick={() => toast.warning('Warning')}>
+        Warning
+      </Button>
+
+      <Button variant="primary" onClick={() => toast.info('Info')}>
+        Info
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/vibes/soul/examples/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/toaster/index.tsx
@@ -1,38 +1,38 @@
-'use client'
+'use client';
 
-import { Button } from '@/vibes/soul/primitives/button'
-import { toast } from '@/vibes/soul/primitives/toaster'
+import { Button } from '@/vibes/soul/primitives/button';
+import { toast } from '@/vibes/soul/primitives/toaster';
 
 export default function Preview() {
   return (
     <div className="grid h-screen place-content-center gap-x-4 gap-y-6">
-      <Button variant="primary" onClick={() => toast.success('Success')}>
+      <Button onClick={() => toast.success('Success')} variant="primary">
         Success
       </Button>
 
-      <Button variant="primary" onClick={() => toast.error('Error')}>
+      <Button onClick={() => toast.error('Error')} variant="primary">
         Error
       </Button>
 
-      <Button variant="primary" onClick={() => toast.warning('Warning')}>
+      <Button onClick={() => toast.warning('Warning')} variant="primary">
         Warning
       </Button>
 
-      <Button variant="primary" onClick={() => toast.info('Info')}>
+      <Button onClick={() => toast.info('Info')} variant="primary">
         Info
       </Button>
 
       <Button
-        variant="primary"
         onClick={() =>
           toast.success('Success', {
             description: 'Description of toast',
             action: { label: 'Undo', onClick: () => console.log('undo') },
           })
         }
+        variant="primary"
       >
         Options
       </Button>
     </div>
-  )
+  );
 }

--- a/apps/web/vibes/soul/navigation.ts
+++ b/apps/web/vibes/soul/navigation.ts
@@ -150,6 +150,12 @@ export const navigation = [
         file: 'docs/textarea.mdx',
         component: 'textarea',
       },
+      {
+        title: 'Toaster',
+        slug: 'toaster',
+        file: 'docs/toaster.mdx',
+        component: 'toaster',
+      },
     ],
   },
   {

--- a/apps/web/vibes/soul/primitives/alert/index.tsx
+++ b/apps/web/vibes/soul/primitives/alert/index.tsx
@@ -1,48 +1,64 @@
 import { clsx } from 'clsx';
-import { AlertTriangle, Check, X } from 'lucide-react';
+import { X } from 'lucide-react';
 
 interface Props {
-  variant: 'success' | 'warning' | 'error';
+  variant: 'success' | 'warning' | 'error' | 'info';
   message: string;
+  description?: string;
+  dismissLabel?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+  onDismiss?: () => void;
 }
 
-export function Alert({ variant, message }: Props) {
+export function Alert({
+  variant,
+  message,
+  description,
+  action,
+  dismissLabel = 'Dismiss',
+  onDismiss,
+}: Props) {
   return (
     <div
-      aria-live="assertive"
       className={clsx(
-        'flex min-w-80 max-w-md items-center rounded-xl px-3 py-2.5',
+        'flex min-w-[284px] max-w-[356px] items-center justify-between gap-2 rounded-xl border border-foreground/10 py-3 pe-3 ps-4 shadow-sm ring-foreground group-focus-visible:outline-none group-focus-visible:ring-2',
         {
           success: 'bg-success-highlight',
           warning: 'bg-warning-highlight',
           error: 'bg-error-highlight',
+          info: 'bg-background',
         }[variant],
       )}
       role="alert"
     >
-      <div
-        className={clsx(
-          'grid aspect-square h-7 place-content-center rounded-full text-foreground',
-          {
-            success: 'bg-success/50',
-            warning: 'bg-warning/30',
-            error: 'bg-error/50',
-          }[variant],
+      <div className="flex flex-col">
+        <span className="text-sm font-normal text-foreground">{message}</span>
+        {Boolean(description) && (
+          <span className="text-xs font-medium text-contrast-400">{description}</span>
         )}
-      >
-        {variant === 'success' && <Check size={16} strokeWidth={1} />}
-        {variant === 'warning' && <AlertTriangle size={16} strokeWidth={1} />}
-        {variant === 'error' && <X size={16} strokeWidth={1} />}
       </div>
 
-      <span className="flex-1 pl-3 pr-5 text-sm leading-normal text-foreground">{message}</span>
+      <div className="flex gap-1">
+        {action && (
+          <button
+            className="flex items-center justify-center rounded-full border-none px-3 py-1.5 text-xs font-semibold ring-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2"
+            onClick={action.onClick}
+          >
+            {action.label}
+          </button>
+        )}
 
-      <button
-        aria-label="Dismiss alert"
-        // onClick={}
-      >
-        <X size={20} strokeWidth={1} />
-      </button>
+        <button
+          aria-label={dismissLabel}
+          className="flex h-8 w-8 items-center justify-center rounded-full border-none ring-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2"
+          onClick={onDismiss}
+        >
+          <X size={20} strokeWidth={1.5} />
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/vibes/soul/primitives/alert/index.tsx
+++ b/apps/web/vibes/soul/primitives/alert/index.tsx
@@ -1,6 +1,8 @@
 import { clsx } from 'clsx';
 import { X } from 'lucide-react';
 
+import { Button } from '@/vibes/soul/primitives/button';
+
 interface Props {
   variant: 'success' | 'warning' | 'error' | 'info';
   message: string;
@@ -41,23 +43,16 @@ export function Alert({
         )}
       </div>
 
-      <div className="flex gap-1">
+      <div className="flex items-center gap-1">
         {action && (
-          <button
-            className="flex items-center justify-center rounded-full border-none px-3 py-1.5 text-xs font-semibold ring-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2"
-            onClick={action.onClick}
-          >
+          <Button onClick={action.onClick} size="x-small" variant="ghost">
             {action.label}
-          </button>
+          </Button>
         )}
 
-        <button
-          aria-label={dismissLabel}
-          className="flex h-8 w-8 items-center justify-center rounded-full border-none ring-foreground hover:bg-foreground/5 focus-visible:outline-none focus-visible:ring-2"
-          onClick={onDismiss}
-        >
-          <X size={20} strokeWidth={1.5} />
-        </button>
+        <Button aria-label={dismissLabel} onClick={onDismiss} size="icon-small" variant="ghost">
+          <X size={20} strokeWidth={1} />
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { CheckIcon, XIcon } from 'lucide-react'
+import { XIcon } from 'lucide-react'
 import { Toaster as Sonner } from 'sonner'
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
@@ -12,23 +12,25 @@ export const Toaster = ({ ...props }: ToasterProps) => {
         unstyled: true,
         classNames: {
           toast:
-            'rounded-xl text-base px-3 py-2 min-w-[284px] max-w-[356px] flex items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 ring-foreground',
+            'rounded-xl p-3 min-w-[284px] max-w-[356px] flex items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 ring-foreground flex',
+          content: 'grow',
+          title: 'font-normal text-sm leading-5',
+          description: 'font-normal text-xs leading-5',
           error: 'group error bg-error-highlight',
           success: 'group success bg-success-highlight',
           warning: 'group warning bg-warning-highlight',
           info: 'group info bg-info-highlight',
-          icon: 'me-2.5 h-7 w-7 rounded-full flex items-center justify-center group-[.error]:bg-error/50 group-[.success]:bg-success/50 group-[.warning]:bg-warning/50 group-[.info]:bg-info/50',
+          icon: 'hidden',
           actionButton:
-            'border-contrast-200 border px-1.5 py-1 rounded-md text-sm focus-visible:outline-none focus-visible:ring-2 ring-foreground ms-auto',
-          closeButton: 'focus-visible:outline-none focus-visible:ring-2 ring-foreground',
+            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold leading-5 p-0.5 rounded-md text-nowrap',
+          cancelButton:
+            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold leading-5 p-0.5 rounded-md text-nowrap',
+          closeButton:
+            'focus-visible:outline-none focus-visible:ring-2 ring-foreground static order-last data-[close-button]:!bg-transparent hover:data-[close-button]:bg-transparent border-none align-middle translate-x-0 translate-y-0 rounded-md',
         },
       }}
       icons={{
-        success: <CheckIcon strokeWidth={1.5} size={16} />,
-        error: <CheckIcon strokeWidth={1.5} size={16} />,
-        warning: <CheckIcon strokeWidth={1.5} size={16} />,
-        info: <CheckIcon strokeWidth={1.5} size={16} />,
-        close: <XIcon strokeWidth={1.5} size={12} />,
+        close: <XIcon strokeWidth={1.5} size={20} />,
       }}
       {...props}
     />

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -14,6 +14,7 @@ interface ToastOptions {
   }
   description?: string
   position?: ToasterProps['position']
+  dismissLabel?: string
 }
 
 export const Toaster = ({ ...props }: ToasterProps) => {

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -1,9 +1,20 @@
 'use client'
 
 import { XIcon } from 'lucide-react'
-import { Toaster as Sonner } from 'sonner'
+import { Toaster as Sonner, toast as SonnerToast } from 'sonner'
+
+import { Alert } from '@/vibes/soul/primitives/alert'
 
 type ToasterProps = React.ComponentProps<typeof Sonner>
+
+interface ToastOptions {
+  action?: {
+    label: string
+    onClick: () => void
+  }
+  description?: string
+  position?: ToasterProps['position']
+}
 
 export const Toaster = ({ ...props }: ToasterProps) => {
   return (
@@ -11,22 +22,7 @@ export const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         unstyled: true,
         classNames: {
-          toast:
-            'rounded-xl ps-4 pe-3 py-3 min-w-[284px] max-w-[356px] text-foreground flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 ring-foreground flex border border-foreground/10 shadow-sm',
-          content: 'grow',
-          title: 'font-normal text-sm',
-          description: 'font-medium text-xs text-contrast-400',
-          error: 'group error bg-error-highlight',
-          success: 'group success bg-success-highlight',
-          warning: 'group warning bg-warning-highlight',
-          info: 'group info bg-background',
-          icon: 'hidden',
-          actionButton:
-            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold py-1.5 px-3 rounded-full text-nowrap hover:bg-foreground/5',
-          cancelButton:
-            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold py-1.5 px-3 rounded-full text-nowrap hover:bg-foreground/5',
-          closeButton:
-            'h-8 w-8 focus-visible:outline-none focus-visible:ring-2 ring-foreground static order-last data-[close-button]:!bg-transparent hover:data-[close-button]:!bg-foreground/5 border-none align-middle translate-x-0 translate-y-0 rounded-full',
+          toast: 'group focus-visible:ring-0',
         },
       }}
       icons={{
@@ -35,4 +31,59 @@ export const Toaster = ({ ...props }: ToasterProps) => {
       {...props}
     />
   )
+}
+
+export const toast = {
+  success: (message: string, options?: ToastOptions) => {
+    const position = options?.position
+
+    const toastId = SonnerToast(
+      <Alert
+        variant="success"
+        message={message}
+        onDismiss={() => SonnerToast.dismiss(toastId)}
+        {...options}
+      />,
+      { position }
+    )
+  },
+  error: (message: string, options?: ToastOptions) => {
+    const position = options?.position
+
+    const toastId = SonnerToast(
+      <Alert
+        variant="error"
+        message={message}
+        onDismiss={() => SonnerToast.dismiss(toastId)}
+        {...options}
+      />,
+      { position }
+    )
+  },
+  warning: (message: string, options?: ToastOptions) => {
+    const position = options?.position
+
+    const toastId = SonnerToast(
+      <Alert
+        variant="warning"
+        message={message}
+        onDismiss={() => SonnerToast.dismiss(toastId)}
+        {...options}
+      />,
+      { position }
+    )
+  },
+  info: (message: string, options?: ToastOptions) => {
+    const position = options?.position
+
+    const toastId = SonnerToast(
+      <Alert
+        variant="info"
+        message={message}
+        onDismiss={() => SonnerToast.dismiss(toastId)}
+        {...options}
+      />,
+      { position }
+    )
+  },
 }

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { CheckIcon, XIcon } from 'lucide-react'
+import { Toaster as Sonner } from 'sonner'
+
+type ToasterProps = React.ComponentProps<typeof Sonner>
+
+export const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      toastOptions={{
+        unstyled: true,
+        classNames: {
+          toast:
+            'rounded-xl text-base px-3 py-2 min-w-[284px] max-w-[356px] flex items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 ring-foreground',
+          error: 'group error bg-error-highlight',
+          success: 'group success bg-success-highlight',
+          warning: 'group warning bg-warning-highlight',
+          info: 'group info bg-info-highlight',
+          icon: 'me-2.5 h-7 w-7 rounded-full flex items-center justify-center group-[.error]:bg-error/50 group-[.success]:bg-success/50 group-[.warning]:bg-warning/50 group-[.info]:bg-info/50',
+          actionButton:
+            'border-contrast-200 border px-1.5 py-1 rounded-md text-sm focus-visible:outline-none focus-visible:ring-2 ring-foreground ms-auto',
+          closeButton: 'focus-visible:outline-none focus-visible:ring-2 ring-foreground',
+        },
+      }}
+      icons={{
+        success: <CheckIcon strokeWidth={1.5} size={16} />,
+        error: <CheckIcon strokeWidth={1.5} size={16} />,
+        warning: <CheckIcon strokeWidth={1.5} size={16} />,
+        info: <CheckIcon strokeWidth={1.5} size={16} />,
+        close: <XIcon strokeWidth={1.5} size={12} />,
+      }}
+      {...props}
+    />
+  )
+}

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -12,7 +12,7 @@ export const Toaster = ({ ...props }: ToasterProps) => {
         unstyled: true,
         classNames: {
           toast:
-            'rounded-xl py-3 px-4 min-w-[284px] max-w-[356px] text-foreground flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 ring-foreground flex border border-foreground/10 shadow-sm',
+            'rounded-xl ps-4 pe-3 py-3 min-w-[284px] max-w-[356px] text-foreground flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 ring-foreground flex border border-foreground/10 shadow-sm',
           content: 'grow',
           title: 'font-normal text-sm',
           description: 'font-medium text-xs text-contrast-400',

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -12,21 +12,21 @@ export const Toaster = ({ ...props }: ToasterProps) => {
         unstyled: true,
         classNames: {
           toast:
-            'rounded-xl p-3 min-w-[284px] max-w-[356px] flex items-center gap-2.5 focus-visible:outline-none focus-visible:ring-2 ring-foreground flex',
+            'rounded-xl py-3 px-4 min-w-[284px] max-w-[356px] text-foreground flex items-center gap-2 focus-visible:outline-none focus-visible:ring-2 ring-foreground flex border border-foreground/10 shadow-sm',
           content: 'grow',
-          title: 'font-normal text-sm leading-5',
-          description: 'font-normal text-xs leading-5',
+          title: 'font-normal text-sm',
+          description: 'font-medium text-xs text-contrast-400',
           error: 'group error bg-error-highlight',
           success: 'group success bg-success-highlight',
           warning: 'group warning bg-warning-highlight',
-          info: 'group info bg-info-highlight',
+          info: 'group info bg-background',
           icon: 'hidden',
           actionButton:
-            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold leading-5 p-0.5 rounded-md text-nowrap',
+            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold py-1.5 px-3 rounded-full text-nowrap hover:bg-foreground/5',
           cancelButton:
-            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold leading-5 p-0.5 rounded-md text-nowrap',
+            'text-xs focus-visible:outline-none focus-visible:ring-2 ring-foreground font-semibold py-1.5 px-3 rounded-full text-nowrap hover:bg-foreground/5',
           closeButton:
-            'focus-visible:outline-none focus-visible:ring-2 ring-foreground static order-last data-[close-button]:!bg-transparent hover:data-[close-button]:bg-transparent border-none align-middle translate-x-0 translate-y-0 rounded-md',
+            'h-8 w-8 focus-visible:outline-none focus-visible:ring-2 ring-foreground static order-last data-[close-button]:!bg-transparent hover:data-[close-button]:!bg-foreground/5 border-none align-middle translate-x-0 translate-y-0 rounded-full',
         },
       }}
       icons={{

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { XIcon } from 'lucide-react'
 import { Toaster as Sonner, toast as SonnerToast } from 'sonner'
 
 import { Alert } from '@/vibes/soul/primitives/alert'
@@ -25,9 +24,6 @@ export const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast: 'group focus-visible:ring-0',
         },
-      }}
-      icons={{
-        close: <XIcon strokeWidth={1.5} size={20} />,
       }}
       {...props}
     />

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -1,19 +1,19 @@
-'use client'
+'use client';
 
-import { Toaster as Sonner, toast as SonnerToast } from 'sonner'
+import { Toaster as Sonner, toast as SonnerToast } from 'sonner';
 
-import { Alert } from '@/vibes/soul/primitives/alert'
+import { Alert } from '@/vibes/soul/primitives/alert';
 
-type ToasterProps = React.ComponentProps<typeof Sonner>
+type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 interface ToastOptions {
   action?: {
-    label: string
-    onClick: () => void
-  }
-  description?: string
-  position?: ToasterProps['position']
-  dismissLabel?: string
+    label: string;
+    onClick: () => void;
+  };
+  description?: string;
+  position?: ToasterProps['position'];
+  dismissLabel?: string;
 }
 
 export const Toaster = ({ ...props }: ToasterProps) => {
@@ -27,60 +27,60 @@ export const Toaster = ({ ...props }: ToasterProps) => {
       }}
       {...props}
     />
-  )
-}
+  );
+};
 
 export const toast = {
   success: (message: string, options?: ToastOptions) => {
-    const position = options?.position
+    const position = options?.position;
 
     const toastId = SonnerToast(
       <Alert
-        variant="success"
         message={message}
         onDismiss={() => SonnerToast.dismiss(toastId)}
+        variant="success"
         {...options}
       />,
-      { position }
-    )
+      { position },
+    );
   },
   error: (message: string, options?: ToastOptions) => {
-    const position = options?.position
+    const position = options?.position;
 
     const toastId = SonnerToast(
       <Alert
-        variant="error"
         message={message}
         onDismiss={() => SonnerToast.dismiss(toastId)}
+        variant="error"
         {...options}
       />,
-      { position }
-    )
+      { position },
+    );
   },
   warning: (message: string, options?: ToastOptions) => {
-    const position = options?.position
+    const position = options?.position;
 
     const toastId = SonnerToast(
       <Alert
-        variant="warning"
         message={message}
         onDismiss={() => SonnerToast.dismiss(toastId)}
+        variant="warning"
         {...options}
       />,
-      { position }
-    )
+      { position },
+    );
   },
   info: (message: string, options?: ToastOptions) => {
-    const position = options?.position
+    const position = options?.position;
 
     const toastId = SonnerToast(
       <Alert
-        variant="info"
         message={message}
         onDismiss={() => SonnerToast.dismiss(toastId)}
+        variant="info"
         {...options}
       />,
-      { position }
-    )
+      { position },
+    );
   },
-}
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sonner:
+        specifier: ^1.7.0
+        version: 1.7.0(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.5.4
@@ -7483,6 +7486,16 @@ packages:
       dot-case: 3.0.4
       tslib: 2.8.1
     dev: true
+
+  /sonner@1.7.0(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-W6dH7m5MujEPyug3lpI2l3TC3Pp1+LTgK0Efg+IHDrBbtEjyCmCHHo6yfNBOsf1tFZ6zf+jceWwB38baC8yO9g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    dependencies:
+      react: 19.0.0-rc-603e6108-20241029
+      react-dom: 19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029)
+    dev: false
 
   /source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}


### PR DESCRIPTION
- Adds the `Toaster` primitive that uses [Sonner](apps/web/vibes/soul/sections/subscribe/index.tsx) for toasts.
- Customize Toaster.
- Updated the docs to include this new primitive.
- Add primitive to preview to enable use of `toast` in other components.

### Demo
https://github.com/user-attachments/assets/635b1c8d-9862-4a69-b9f6-bd9905db4d34

### Notes
> [!IMPORTANT]  
> There is a divergence from the proposed designs in how we handle the close button:

`Sonner` has it on the corner since the toast can have an action on the right side of the toast. 

![Screenshot 2024-12-04 at 4 38 09 PM](https://github.com/user-attachments/assets/7dbce88e-0dac-4407-98cd-7debf04645aa)

The proposed designs has the close/dismiss button as an action:

![image](https://github.com/user-attachments/assets/8355d1a4-94dc-41a7-9772-06abbf4b38a7)

I feel it may be important to retain the action prop api for Toast so I think it is a better implementation to keep the close button in the corner as it currently works from the box in Sonner, but I want to hear what @andrewreifman might have to say on this.

Another option is to have a custom `toast` function that does not accept actions.

