### PR TITLE
feat: update subscribe section to show toast and intl props

### DIFF
--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
@@ -3,17 +3,20 @@ import { parseWithZod } from '@conform-to/zod';
 
 import { schema } from '@/vibes/soul/primitives/inline-email-form/schema';
 
-export async function action(lastResult: SubmissionResult | null, formData: FormData) {
+export async function action(
+  _lastResult: { lastResult: SubmissionResult | null; },
+  formData: FormData,
+) {
   'use server';
 
   const submission = parseWithZod(formData, { schema });
 
   if (submission.status !== 'success') {
-    return submission.reply({ formErrors: ['Boom!'] });
+    return { lastResult: submission.reply({ formErrors: ['Boom!'] }) };
   }
 
   // Simulate a network request
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
-  return { ...submission.reply(), successMessage: 'Subscribed!' };
+  return { lastResult: submission.reply(), successMessage: 'Subscribed!' };
 }

--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
@@ -15,7 +15,5 @@ export async function action(lastResult: SubmissionResult | null, formData: Form
   // Simulate a network request
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
-  // const user = await logIn(submission.value)
-
-  return submission.reply({ resetForm: true });
+  return submission.reply();
 }

--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
@@ -15,5 +15,5 @@ export async function action(lastResult: SubmissionResult | null, formData: Form
   // Simulate a network request
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
-  return {...submission.reply({ resetForm: true }), successMessage: 'Subscribed!'};
+  return { ...submission.reply({ resetForm: true }), successMessage: 'Subscribed!' };
 }

--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
@@ -4,7 +4,7 @@ import { parseWithZod } from '@conform-to/zod';
 import { schema } from '@/vibes/soul/primitives/inline-email-form/schema';
 
 export async function action(
-  _lastResult: { lastResult: SubmissionResult | null; },
+  _lastResult: { lastResult: SubmissionResult | null },
   formData: FormData,
 ) {
   'use server';

--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
@@ -15,5 +15,5 @@ export async function action(lastResult: SubmissionResult | null, formData: Form
   // Simulate a network request
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
-  return submission.reply();
+  return {...submission.reply({ resetForm: true }), successMessage: 'Subscribed!'};
 }

--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/actions.ts
@@ -15,5 +15,5 @@ export async function action(lastResult: SubmissionResult | null, formData: Form
   // Simulate a network request
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
-  return { ...submission.reply({ resetForm: true }), successMessage: 'Subscribed!' };
+  return { ...submission.reply(), successMessage: 'Subscribed!' };
 }

--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/index.tsx
@@ -5,7 +5,7 @@ import { action } from './actions';
 export default function Preview() {
   return (
     <div className="p-10">
-      <InlineEmailForm action={action} successMessage="Submitted!" />
+      <InlineEmailForm action={action} />
     </div>
   );
 }

--- a/apps/web/vibes/soul/examples/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/inline-email-form/index.tsx
@@ -5,7 +5,7 @@ import { action } from './actions';
 export default function Preview() {
   return (
     <div className="p-10">
-      <InlineEmailForm action={action} />
+      <InlineEmailForm action={action} successMessage="Submitted!" />
     </div>
   );
 }

--- a/apps/web/vibes/soul/examples/sections/subscribe/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/subscribe/index.tsx
@@ -1,27 +1,5 @@
-// import { redirect } from 'next/navigation'
-// import { SubmissionResult } from '@conform-to/react'
-// import { parseWithZod } from '@conform-to/zod'
-// import { z } from 'zod'
 import { action } from '@/vibes/soul/examples/primitives/inline-email-form/actions';
 import { Subscribe } from '@/vibes/soul/sections/subscribe';
-
-// async function action(prevState: unknown, formData: FormData): Promise<SubmissionResult> {
-//   'use server'
-
-//   const submission = parseWithZod(formData, {
-//     schema: z.object({
-//       email: z.string().email(),
-//     }),
-//   })
-
-//   console.log({ submission })
-
-//   if (submission.status !== 'success') {
-//     return submission.reply()
-//   }
-
-//   return redirect('/f?value=')
-// }
 
 export default function Preview() {
   const image = {

--- a/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
@@ -25,9 +25,13 @@ export function InlineEmailForm({
   className?: string;
   placeholder?: string;
   submitLabel?: string;
-  action: Action<(SubmissionResult & { successMessage?: string }) | null, FormData>;
+  action: Action<{ lastResult: SubmissionResult | null; successMessage?: string }, FormData>;
 }) {
-  const [lastResult, formAction, isPending] = useActionState(action, null);
+  const [{ lastResult, successMessage }, formAction, isPending] = useActionState(action, {
+    lastResult: null,
+  });
+
+  console.log('lastResult', lastResult);
 
   const [form, fields] = useForm({
     lastResult,
@@ -72,8 +76,8 @@ export function InlineEmailForm({
           {error}
         </FormStatus>
       ))}
-      {form.status === 'success' && lastResult?.successMessage != null && (
-        <FormStatus>{lastResult.successMessage}</FormStatus>
+      {form.status === 'success' && successMessage != null && (
+        <FormStatus>{successMessage}</FormStatus>
       )}
     </form>
   );

--- a/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
@@ -10,7 +10,6 @@ import { FieldError } from '@/vibes/soul/form/field-error';
 import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
 
-
 import { schema } from './schema';
 
 type Action<State, Payload> = (
@@ -29,7 +28,7 @@ export function InlineEmailForm({
   placeholder?: string;
   submitLabel?: string;
   dismissLabel?: string;
-  action: Action<SubmissionResult & {successMessage?: string} | null, FormData>;
+  action: Action<(SubmissionResult & { successMessage?: string }) | null, FormData>;
 }) {
   const [lastResult, formAction, isPending] = useActionState(action, null);
 

--- a/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
@@ -23,15 +23,13 @@ export function InlineEmailForm({
   action,
   submitLabel = 'Submit',
   placeholder = 'Enter your email',
-  successMessage,
   dismissLabel,
 }: {
   className?: string;
   placeholder?: string;
   submitLabel?: string;
-  successMessage: string;
   dismissLabel?: string;
-  action: Action<SubmissionResult | null, FormData>;
+  action: Action<SubmissionResult & {successMessage?: string} | null, FormData>;
 }) {
   const [lastResult, formAction, isPending] = useActionState(action, null);
 
@@ -45,11 +43,11 @@ export function InlineEmailForm({
   });
 
   useEffect(() => {
-    if (lastResult?.status === 'success') {
-      toast.success(successMessage, { dismissLabel });
+    if (typeof lastResult?.successMessage === 'string') {
+      toast.success(lastResult.successMessage, { dismissLabel });
       return;
     }
-  }, [dismissLabel, lastResult, successMessage]);
+  }, [dismissLabel, lastResult]);
 
   const { errors = [] } = fields.email;
 

--- a/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
@@ -6,8 +6,10 @@ import { clsx } from 'clsx';
 import { ArrowRight } from 'lucide-react';
 import { useActionState, useEffect } from 'react';
 
-import { FieldError } from '../../form/field-error';
-import { Button } from '../button';
+import { FieldError } from '@/vibes/soul/form/field-error';
+import { Button } from '@/vibes/soul/primitives/button';
+import { toast } from '@/vibes/soul/primitives/toaster';
+
 
 import { schema } from './schema';
 
@@ -21,10 +23,14 @@ export function InlineEmailForm({
   action,
   submitLabel = 'Submit',
   placeholder = 'Enter your email',
+  successMessage,
+  dismissLabel,
 }: {
   className?: string;
   placeholder?: string;
   submitLabel?: string;
+  successMessage: string;
+  dismissLabel?: string;
   action: Action<SubmissionResult | null, FormData>;
 }) {
   const [lastResult, formAction, isPending] = useActionState(action, null);
@@ -35,15 +41,15 @@ export function InlineEmailForm({
       return parseWithZod(formData, { schema });
     },
     shouldValidate: 'onSubmit',
-    shouldRevalidate: 'onInput',
+    shouldRevalidate: 'onBlur',
   });
 
   useEffect(() => {
-    if (lastResult?.error) {
-      console.log(lastResult.error);
+    if (lastResult?.status === 'success') {
+      toast.success(successMessage, { dismissLabel });
       return;
     }
-  }, [lastResult]);
+  }, [dismissLabel, lastResult, successMessage]);
 
   const { errors = [] } = fields.email;
 

--- a/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
@@ -62,6 +62,7 @@ export function InlineEmailForm({
         <input
           {...getInputProps(fields.email, { type: 'email' })}
           className="placeholder-contrast-gray-500 h-14 w-full bg-transparent pl-5 pr-16 text-foreground placeholder:font-normal focus:outline-none"
+          data-1p-ignore
           key={fields.email.id}
           placeholder={placeholder}
         />

--- a/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
@@ -4,11 +4,10 @@ import { SubmissionResult, getFormProps, getInputProps, useForm } from '@conform
 import { parseWithZod } from '@conform-to/zod';
 import { clsx } from 'clsx';
 import { ArrowRight } from 'lucide-react';
-import { useActionState, useEffect } from 'react';
+import { useActionState } from 'react';
 
-import { FieldError } from '@/vibes/soul/form/field-error';
+import { FormStatus } from '@/vibes/soul/form/form-status';
 import { Button } from '@/vibes/soul/primitives/button';
-import { toast } from '@/vibes/soul/primitives/toaster';
 
 import { schema } from './schema';
 
@@ -22,12 +21,10 @@ export function InlineEmailForm({
   action,
   submitLabel = 'Submit',
   placeholder = 'Enter your email',
-  dismissLabel,
 }: {
   className?: string;
   placeholder?: string;
   submitLabel?: string;
-  dismissLabel?: string;
   action: Action<(SubmissionResult & { successMessage?: string }) | null, FormData>;
 }) {
   const [lastResult, formAction, isPending] = useActionState(action, null);
@@ -38,15 +35,8 @@ export function InlineEmailForm({
       return parseWithZod(formData, { schema });
     },
     shouldValidate: 'onSubmit',
-    shouldRevalidate: 'onBlur',
+    shouldRevalidate: 'onInput',
   });
-
-  useEffect(() => {
-    if (typeof lastResult?.successMessage === 'string') {
-      toast.success(lastResult.successMessage, { dismissLabel });
-      return;
-    }
-  }, [dismissLabel, lastResult]);
 
   const { errors = [] } = fields.email;
 
@@ -78,8 +68,13 @@ export function InlineEmailForm({
         </div>
       </div>
       {errors.map((error, index) => (
-        <FieldError key={index}>{error}</FieldError>
+        <FormStatus key={index} type="error">
+          {error}
+        </FormStatus>
       ))}
+      {form.status === 'success' && lastResult?.successMessage != null && (
+        <FormStatus>{lastResult.successMessage}</FormStatus>
+      )}
     </form>
   );
 }

--- a/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
+++ b/apps/web/vibes/soul/primitives/inline-email-form/index.tsx
@@ -31,8 +31,6 @@ export function InlineEmailForm({
     lastResult: null,
   });
 
-  console.log('lastResult', lastResult);
-
   const [form, fields] = useForm({
     lastResult,
     onValidate({ formData }) {

--- a/apps/web/vibes/soul/sections/subscribe/index.tsx
+++ b/apps/web/vibes/soul/sections/subscribe/index.tsx
@@ -12,12 +12,16 @@ export function Subscribe({
   title,
   description,
   placeholder,
+  successMessage = 'Thanks for subscribing!',
+  dismissLabel,
 }: {
   action: Action<SubmissionResult | null, FormData>;
   image?: { src: string; alt: string };
   title: string;
   description?: string;
   placeholder?: string;
+  successMessage?: string;
+  dismissLabel?: string;
 }) {
   return (
     <section className="bg-primary-shadow @container">
@@ -49,7 +53,13 @@ export function Subscribe({
               </h2>
               <p className="text-primary-highlight opacity-75">{description}</p>
             </div>
-            <InlineEmailForm action={action} className="flex-1" placeholder={placeholder} />
+            <InlineEmailForm
+              action={action}
+              className="flex-1"
+              dismissLabel={dismissLabel}
+              placeholder={placeholder}
+              successMessage={successMessage}
+            />
           </div>
         </div>
       </div>

--- a/apps/web/vibes/soul/sections/subscribe/index.tsx
+++ b/apps/web/vibes/soul/sections/subscribe/index.tsx
@@ -12,14 +12,12 @@ export function Subscribe({
   title,
   description,
   placeholder,
-  dismissLabel,
 }: {
   action: Action<SubmissionResult | null, FormData>;
   image?: { src: string; alt: string };
   title: string;
   description?: string;
   placeholder?: string;
-  dismissLabel?: string;
 }) {
   return (
     <section className="bg-primary-shadow @container">
@@ -40,9 +38,7 @@ export function Subscribe({
           <div
             className={clsx(
               'flex w-full flex-col gap-10 px-4 py-10 @xl:px-6 @xl:py-14 @4xl:gap-16 @4xl:px-8 @4xl:py-20',
-              image != null
-                ? '@4xl:max-w-4xl'
-                : 'mx-auto max-w-screen-2xl @4xl:flex-row @4xl:items-center',
+              image != null ? '@4xl:max-w-4xl' : 'mx-auto max-w-screen-2xl @4xl:flex-row',
             )}
           >
             <div className="flex-1">
@@ -51,12 +47,7 @@ export function Subscribe({
               </h2>
               <p className="text-primary-highlight opacity-75">{description}</p>
             </div>
-            <InlineEmailForm
-              action={action}
-              className="flex-1"
-              dismissLabel={dismissLabel}
-              placeholder={placeholder}
-            />
+            <InlineEmailForm action={action} className="flex-1" placeholder={placeholder} />
           </div>
         </div>
       </div>

--- a/apps/web/vibes/soul/sections/subscribe/index.tsx
+++ b/apps/web/vibes/soul/sections/subscribe/index.tsx
@@ -12,7 +12,6 @@ export function Subscribe({
   title,
   description,
   placeholder,
-  successMessage = 'Thanks for subscribing!',
   dismissLabel,
 }: {
   action: Action<SubmissionResult | null, FormData>;
@@ -20,7 +19,6 @@ export function Subscribe({
   title: string;
   description?: string;
   placeholder?: string;
-  successMessage?: string;
   dismissLabel?: string;
 }) {
   return (
@@ -58,7 +56,6 @@ export function Subscribe({
               className="flex-1"
               dismissLabel={dismissLabel}
               placeholder={placeholder}
-              successMessage={successMessage}
             />
           </div>
         </div>

--- a/apps/web/vibes/soul/sections/subscribe/index.tsx
+++ b/apps/web/vibes/soul/sections/subscribe/index.tsx
@@ -13,7 +13,7 @@ export function Subscribe({
   description,
   placeholder,
 }: {
-  action: Action<SubmissionResult | null, FormData>;
+  action: Action<{ lastResult: SubmissionResult | null; successMessage?: string }, FormData>;
   image?: { src: string; alt: string };
   title: string;
   description?: string;


### PR DESCRIPTION
+ Update component to show toast on success
+ Add `successMessage` prop
+ Add `dismissLabel` prop
+ Change revalidation `onBlur` (this felt better for me)

As a side note: 1password is trying to save this field.

https://github.com/user-attachments/assets/c65ca487-d4fd-424d-b351-3e0bd76fcb19

