### PR TITLE
feat: add empty state to ProductsCarousel

### DIFF
--- a/apps/web/vibes/soul/examples/primitives/products-carousel/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/products-carousel/index.tsx
@@ -1,7 +1,7 @@
 import { getProducts } from '@/vibes/soul/data';
 import { ProductsCarousel } from '@/vibes/soul/primitives/products-carousel';
 
-export default async function Preview() {
-  const products = await getProducts('Warm');
+export default function Preview() {
+  const products = getProducts('Warm');
   return <ProductsCarousel products={products} />;
 }

--- a/apps/web/vibes/soul/examples/sections/featured-products-carousel/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-products-carousel/index.tsx
@@ -1,11 +1,9 @@
 import { getProducts } from '@/vibes/soul/data';
-import {
-  FeaturedProductsCarousel,
-  FeaturedProductsCarouselSkeleton,
-} from '@/vibes/soul/sections/featured-products-carousel';
+import { FeaturedProductsCarousel } from '@/vibes/soul/sections/featured-products-carousel';
 
-export default async function Preview() {
-  const featuredProducts = await getProducts('Electric');
+export default function Preview() {
+  const featuredProducts = getProducts('Electric');
+
   return (
     <>
       <FeaturedProductsCarousel
@@ -15,9 +13,12 @@ export default async function Preview() {
         title="Our Plants"
       />
 
-      <FeaturedProductsCarouselSkeleton
+      <FeaturedProductsCarousel
         cta={{ href: '#', label: 'Shop Now' }}
         description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore."
+        emptyStateSubtitle="Change your filters to see more products"
+        emptyStateTitle="No products found"
+        products={[]}
         title="Our Plants"
       />
     </>

--- a/apps/web/vibes/soul/primitives/product-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/index.tsx
@@ -1,4 +1,3 @@
-import { clsx } from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -86,25 +85,20 @@ export function ProductCard({
 
 export function ProductCardSkeleton({ className }: { className?: string }) {
   return (
-    <div className={clsx('animate-pulse', className)}>
-      <div className="group flex cursor-pointer flex-col gap-2 rounded-xl ring-primary ring-offset-4 focus-visible:outline-0 focus-visible:ring-2 @md:rounded-2xl">
-        <div className="relative aspect-[5/6] overflow-hidden rounded-[inherit] bg-contrast-100">
-          <div className="w-full scale-100 select-none bg-contrast-100 object-cover transition-transform duration-500 ease-out group-hover:scale-110" />
-        </div>
-      </div>
-
+    <div className={className}>
+      <div className="flex aspect-[5/6] flex-col gap-2 rounded-xl bg-contrast-100 @md:rounded-2xl" />
       <div className="mt-2 flex flex-col items-start gap-x-4 gap-y-3 px-1 @xs:mt-3 @2xl:flex-row">
         <div className="flex-1">
-          <div className="group flex flex-col text-base">
-            <span className="inline-flex h-[1lh] items-center font-semibold">
+          <div className="flex flex-col text-base">
+            <div className="flex h-[1lh] items-center">
               <span className="block h-[1ex] w-[10ch] rounded-sm bg-contrast-100" />
-            </span>
-            <span className="mb-2 inline-flex h-[1lh] items-center text-sm font-normal text-contrast-400">
+            </div>
+            <div className="mb-2 flex h-[1lh] items-center text-sm font-normal text-contrast-400">
               <span className="block h-[1ex] w-[8ch] rounded-sm bg-contrast-100" />
-            </span>
-            <span className="inline-flex h-[1lh] items-center font-semibold">
+            </div>
+            <div className="flex h-[1lh] items-center">
               <span className="block h-[1ex] w-[5ch] rounded-sm bg-contrast-100" />
-            </span>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/vibes/soul/primitives/products-carousel/index.tsx
+++ b/apps/web/vibes/soul/primitives/products-carousel/index.tsx
@@ -20,61 +20,63 @@ export type CarouselProduct = CardProduct;
 interface Props {
   products: Streamable<CarouselProduct[]>;
   className?: string;
-  emptyStateMessage?: string;
+  emptyStateTitle?: string;
+  emptyStateSubtitle?: string;
 }
 
 export function ProductsCarousel({
   products: streamableProducts,
   className,
-  emptyStateMessage = 'No products found',
+  emptyStateTitle,
+  emptyStateSubtitle,
 }: Props) {
   return (
-    <Carousel className={className}>
-      <CarouselContent className="mb-10">
-        <Stream fallback={<ProductsCarouselSkeleton />} value={streamableProducts}>
-          {(products) => {
-            if (products.length === 0) {
-              return <ProductsCarouselSkeleton message={emptyStateMessage} />;
-            }
+    <Stream fallback={<ProductsCarouselSkeleton pending />} value={streamableProducts}>
+      {(products) => {
+        if (products.length === 0) {
+          return (
+            <ProductsCarouselEmptyState
+              emptyStateSubtitle={emptyStateSubtitle}
+              emptyStateTitle={emptyStateTitle}
+            />
+          );
+        }
 
-            return products.map((product) => (
-              <CarouselItem
-                className="basis-full @md:basis-1/2 @lg:basis-1/3 @2xl:basis-1/4"
-                key={product.id}
-              >
-                <ProductCard product={product} />
-              </CarouselItem>
-            ));
-          }}
-        </Stream>
-      </CarouselContent>
-      <div className="flex w-full items-center justify-between">
-        <CarouselScrollbar />
-        <CarouselButtons />
-      </div>
-    </Carousel>
+        return (
+          <Carousel className={className}>
+            <CarouselContent className="mb-10">
+              {products.map((product) => (
+                <CarouselItem
+                  className="basis-full @md:basis-1/2 @lg:basis-1/3 @2xl:basis-1/4"
+                  key={product.id}
+                >
+                  <ProductCard product={product} />
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <div className="flex w-full items-center justify-between">
+              <CarouselScrollbar />
+              <CarouselButtons />
+            </div>
+          </Carousel>
+        );
+      }}
+    </Stream>
   );
 }
 
 export function ProductsCarouselSkeleton({
   className,
-  message,
   count = 8,
+  pending = false,
 }: {
   className?: string;
-  message?: string;
   count?: number;
+  pending?: boolean;
 }) {
   return (
-    <Carousel className={className}>
-      <CarouselContent
-        className={clsx(
-          'relative mb-10',
-          message != null &&
-            message !== '' &&
-            '[mask-image:radial-gradient(circle,transparent,black)]',
-        )}
-      >
+    <Carousel className={className} data-pending={pending ? '' : undefined}>
+      <CarouselContent className="mb-10">
         {Array.from({ length: count }).map((_, index) => (
           <CarouselItem
             className="basis-full @md:basis-1/2 @lg:basis-1/3 @2xl:basis-1/4"
@@ -88,7 +90,45 @@ export function ProductsCarouselSkeleton({
         <CarouselScrollbar />
         <CarouselButtons />
       </div>
-      <div className="absolute inset-0 flex items-center justify-center text-lg">{message}</div>
+    </Carousel>
+  );
+}
+
+export function ProductsCarouselEmptyState({
+  className,
+  count = 8,
+  emptyStateTitle,
+  emptyStateSubtitle,
+}: {
+  className?: string;
+  count?: number;
+  emptyStateTitle?: string;
+  emptyStateSubtitle?: string;
+}) {
+  return (
+    <Carousel className={clsx('relative', className)}>
+      <CarouselContent
+        className={clsx(
+          'mb-10 [mask-image:linear-gradient(to_top,_transparent_0%,_hsl(var(--background))_75%)]',
+        )}
+      >
+        {Array.from({ length: count }).map((_, index) => (
+          <CarouselItem
+            className="basis-full @md:basis-1/2 @lg:basis-1/3 @2xl:basis-1/4"
+            key={index}
+          >
+            <ProductCardSkeleton />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <div className="absolute inset-0 mx-auto px-3 py-16 pb-3 @4xl:px-10 @4xl:pb-10 @4xl:pt-28">
+        <div className="mx-auto max-w-xl space-y-2 text-center @4xl:space-y-3">
+          <h3 className="@4x:leading-none font-heading text-2xl leading-tight text-foreground @4xl:text-4xl">
+            {emptyStateTitle}
+          </h3>
+          <p className="text-sm text-contrast-500 @4xl:text-lg">{emptyStateSubtitle}</p>
+        </div>
+      </div>
     </Carousel>
   );
 }

--- a/apps/web/vibes/soul/sections/featured-products-carousel/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-products-carousel/index.tsx
@@ -1,12 +1,6 @@
-import { Suspense } from 'react';
-
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { AnimatedLink } from '@/vibes/soul/primitives/animated-link';
-import {
-  CarouselProduct,
-  ProductsCarousel,
-  ProductsCarouselSkeleton,
-} from '@/vibes/soul/primitives/products-carousel';
+import { CarouselProduct, ProductsCarousel } from '@/vibes/soul/primitives/products-carousel';
 
 interface Link {
   label: string;
@@ -18,41 +12,20 @@ interface Props {
   description?: string;
   cta?: Link;
   products: Streamable<CarouselProduct[]>;
+  emptyStateTitle?: string;
+  emptyStateSubtitle?: string;
 }
 
-export function FeaturedProductsCarousel({ title, description, cta, products }: Props) {
-  return (
-    <section className="overflow-hidden @container">
-      <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
-        <div className="mb-6 flex w-full flex-row flex-wrap items-end justify-between gap-x-8 gap-y-6 text-foreground @4xl:mb-8">
-          <div>
-            <h2 className="font-heading text-2xl leading-none @xl:text-3xl @4xl:text-4xl">
-              {title}
-            </h2>
-            {description != null && description !== '' && (
-              <p className="mt-3 max-w-xl leading-relaxed text-contrast-500">{description}</p>
-            )}
-          </div>
-
-          {cta != null && cta.href !== '' && cta.label !== '' && (
-            <AnimatedLink className="mr-3" label={cta.label} link={{ href: cta.href }} />
-          )}
-        </div>
-        <Suspense fallback={<ProductsCarouselSkeleton />}>
-          <ProductsCarousel products={products} />
-        </Suspense>
-      </div>
-    </section>
-  );
-}
-
-export function FeaturedProductsCarouselSkeleton({
+export function FeaturedProductsCarousel({
   title,
   description,
   cta,
-}: Omit<Props, 'products'>) {
+  products,
+  emptyStateTitle,
+  emptyStateSubtitle,
+}: Props) {
   return (
-    <section className="overflow-hidden @container">
+    <section className="group/pending overflow-hidden @container">
       <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
         <div className="mb-6 flex w-full flex-row flex-wrap items-end justify-between gap-x-8 gap-y-6 text-foreground @4xl:mb-8">
           <div>
@@ -68,7 +41,13 @@ export function FeaturedProductsCarouselSkeleton({
             <AnimatedLink className="mr-3" label={cta.label} link={{ href: cta.href }} />
           )}
         </div>
-        <ProductsCarouselSkeleton />
+        <div className="group-has-[[data-pending]]/pending:animate-pulse">
+          <ProductsCarousel
+            emptyStateSubtitle={emptyStateSubtitle}
+            emptyStateTitle={emptyStateTitle}
+            products={products}
+          />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## What/Why?

- Adds empty state to the `ProductsCarousel` component
- Simplifies examples for the `FeaturedProductsCarousel` by using a single component to handle loading and empty states
- Adds optional `loading` prop to the `ProductsCarousel` component to remove animation on the empty state
- Removes separate components for rendering `ProductsCarouselSkeleton` and `ProductsCarouselEmptyState`


https://github.com/user-attachments/assets/7394b0d2-a8a0-4f87-95fe-13ec3510154e