### PR TITLE
fix: imports for Stream and Streamable in ProductsCarousel

### DIFF
--- a/apps/web/vibes/soul/primitives/products-carousel/index.tsx
+++ b/apps/web/vibes/soul/primitives/products-carousel/index.tsx
@@ -1,5 +1,6 @@
 import { clsx } from 'clsx';
 
+import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import {
   Carousel,
   CarouselButtons,
@@ -12,8 +13,6 @@ import {
   ProductCard,
   ProductCardSkeleton,
 } from '@/vibes/soul/primitives/product-card';
-
-import { Stream, Streamable } from '../../lib/streamable';
 
 export type CarouselProduct = CardProduct;
 


### PR DESCRIPTION
## What/Why
- Fixes import for `Stream` and `Streamable` in the `ProductsCarousel`

## Testing

Locally