### PR TITLE
feat: add empty state to product list section

### DIFF
--- a/apps/web/vibes/soul/examples/sections/featured-products-carousel/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-products-carousel/index.tsx
@@ -2,24 +2,35 @@ import { getProducts } from '@/vibes/soul/data';
 import { FeaturedProductsCarousel } from '@/vibes/soul/sections/featured-products-carousel';
 
 export default function Preview() {
-  const featuredProducts = getProducts('Electric');
+  const featuredProducts = {
+    title: 'Our plants',
+    description:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore.',
+    cta: {
+      label: 'Shop Now',
+      href: '#',
+    },
+    products: getProducts('Electric'),
+    emptyStateSubtitle: 'Try browsing our complete catalog of products.',
+    emptyStateTitle: 'No products found',
+  };
 
   return (
     <>
       <FeaturedProductsCarousel
-        cta={{ href: '#', label: 'Shop Now' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore."
-        products={featuredProducts}
-        title="Our Plants"
+        cta={featuredProducts.cta}
+        description={featuredProducts.description}
+        products={featuredProducts.products}
+        title={featuredProducts.title}
       />
 
       <FeaturedProductsCarousel
-        cta={{ href: '#', label: 'Shop Now' }}
-        description="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore."
-        emptyStateSubtitle="Try browsing our complete catalog of products."
-        emptyStateTitle="No products found"
+        cta={featuredProducts.cta}
+        description={featuredProducts.description}
+        emptyStateSubtitle={featuredProducts.emptyStateSubtitle}
+        emptyStateTitle={featuredProducts.emptyStateTitle}
         products={[]}
-        title="Our Plants"
+        title={featuredProducts.title}
       />
     </>
   );

--- a/apps/web/vibes/soul/examples/sections/featured-products-list/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-products-list/electric.tsx
@@ -9,29 +9,25 @@ export const featuredProducts = {
     href: '#',
   },
   products: getProducts('Electric'),
+  emptyStateSubtitle: 'Try browsing our complete catalog of products.',
+  emptyStateTitle: 'No products found',
 };
 
 export default function Preview() {
   return (
     <>
       <FeaturedProductsList
-        cta={{
-          label: featuredProducts.cta.label,
-          href: featuredProducts.cta.href,
-        }}
+        cta={featuredProducts.cta}
         description={featuredProducts.description}
         products={featuredProducts.products}
         title={featuredProducts.title}
       />
 
       <FeaturedProductsList
-        cta={{
-          label: featuredProducts.cta.label,
-          href: featuredProducts.cta.href,
-        }}
+        cta={featuredProducts.cta}
         description={featuredProducts.description}
-        emptyStateSubtitle="Try browsing our complete catalog of products."
-        emptyStateTitle="No products found"
+        emptyStateSubtitle={featuredProducts.emptyStateSubtitle}
+        emptyStateTitle={featuredProducts.emptyStateTitle}
         products={[]}
         title={featuredProducts.title}
       />

--- a/apps/web/vibes/soul/examples/sections/featured-products-list/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-products-list/luxury.tsx
@@ -10,29 +10,25 @@ export const featuredProducts = {
     href: '#',
   },
   products: getProducts('Luxury'),
+  emptyStateSubtitle: 'Try browsing our complete catalog of products.',
+  emptyStateTitle: 'No products found',
 };
 
 export default function Preview() {
   return (
     <>
       <FeaturedProductsList
-        cta={{
-          label: featuredProducts.cta.label,
-          href: featuredProducts.cta.href,
-        }}
+        cta={featuredProducts.cta}
         description={featuredProducts.description}
         products={featuredProducts.products}
         title={featuredProducts.title}
       />
 
       <FeaturedProductsList
-        cta={{
-          label: featuredProducts.cta.label,
-          href: featuredProducts.cta.href,
-        }}
+        cta={featuredProducts.cta}
         description={featuredProducts.description}
-        emptyStateSubtitle="Try browsing our complete catalog of products."
-        emptyStateTitle="No products found"
+        emptyStateSubtitle={featuredProducts.emptyStateSubtitle}
+        emptyStateTitle={featuredProducts.emptyStateTitle}
         products={[]}
         title={featuredProducts.title}
       />

--- a/apps/web/vibes/soul/examples/sections/featured-products-list/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-products-list/warm.tsx
@@ -10,29 +10,25 @@ export const featuredProducts = {
     href: '#',
   },
   products: getProducts('Warm'),
+  emptyStateSubtitle: 'Try browsing our complete catalog of products.',
+  emptyStateTitle: 'No products found',
 };
 
 export default function Preview() {
   return (
     <>
       <FeaturedProductsList
-        cta={{
-          label: featuredProducts.cta.label,
-          href: featuredProducts.cta.href,
-        }}
+        cta={featuredProducts.cta}
         description={featuredProducts.description}
         products={featuredProducts.products}
         title={featuredProducts.title}
       />
 
       <FeaturedProductsList
-        cta={{
-          label: featuredProducts.cta.label,
-          href: featuredProducts.cta.href,
-        }}
+        cta={featuredProducts.cta}
         description={featuredProducts.description}
-        emptyStateSubtitle="Try browsing our complete catalog of products."
-        emptyStateTitle="No products found"
+        emptyStateSubtitle={featuredProducts.emptyStateSubtitle}
+        emptyStateTitle={featuredProducts.emptyStateTitle}
         products={[]}
         title={featuredProducts.title}
       />

--- a/apps/web/vibes/soul/examples/sections/products-list-section/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/products-list-section/electric.tsx
@@ -12,25 +12,33 @@ export default async function Preview({
   const { [compareParamName]: compare, [sortParamName]: sort, ...filterParams } = parsedParams;
 
   const filters = getFilters('Electric');
-  const productsPromise = getProducts('Electric', filterParams);
   const sortOptions = getSortOptions();
   const breadcrumbs = getBreadcrumbs('Electric');
+
+  const productsList = {
+    title: 'Plants',
+    products: getProducts('Electric', filterParams),
+    emptyStateSubtitle: 'Change your filters to see more products',
+    emptyStateTitle: 'No products found',
+  };
 
   return (
     <div className="p-6">
       <ProductsListSection
         breadcrumbs={breadcrumbs}
         compareParamName={compareParamName}
-        compareProducts={productsPromise.then((products) =>
+        compareProducts={productsList.products.then((products) =>
           products.filter((product) => compare?.includes(product.id)),
         )}
+        emptyStateSubtitle={productsList.emptyStateSubtitle}
+        emptyStateTitle={productsList.emptyStateTitle}
         filters={filters}
         paginationInfo={{ endCursor: '10' }}
-        products={productsPromise}
+        products={productsList.products}
         sortOptions={sortOptions}
         sortParamName={sortParamName}
-        title="Plants"
-        totalCount={productsPromise.then((products) => products.length)}
+        title={productsList.title}
+        totalCount={productsList.products.then((products) => products.length)}
       />
     </div>
   );

--- a/apps/web/vibes/soul/examples/sections/products-list-section/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/products-list-section/luxury.tsx
@@ -11,26 +11,34 @@ export default async function Preview({
   const parsedParams = cache.parse(await searchParams);
   const { [compareParamName]: compare, [sortParamName]: sort, ...filterParams } = parsedParams;
 
-  const productsPromise = getProducts('Luxury', filterParams);
   const filters = getFilters('Luxury');
   const sortOptions = getSortOptions();
   const breadcrumbs = getBreadcrumbs('Luxury');
+
+  const productsList = {
+    title: 'Shoes',
+    products: getProducts('Luxury', filterParams),
+    emptyStateSubtitle: 'Change your filters to see more products',
+    emptyStateTitle: 'No products found',
+  };
 
   return (
     <div className="p-6">
       <ProductsListSection
         breadcrumbs={breadcrumbs}
         compareParamName={compareParamName}
-        compareProducts={productsPromise.then((products) =>
+        compareProducts={productsList.products.then((products) =>
           products.filter((product) => compare?.includes(product.id)),
         )}
+        emptyStateSubtitle={productsList.emptyStateSubtitle}
+        emptyStateTitle={productsList.emptyStateTitle}
         filters={filters}
         paginationInfo={{ startCursor: '1', endCursor: '10' }}
-        products={productsPromise}
+        products={productsList.products}
         sortOptions={sortOptions}
         sortParamName={sortParamName}
-        title="Shoes"
-        totalCount={productsPromise.then((products) => products.length)}
+        title={productsList.title}
+        totalCount={productsList.products.then((products) => products.length)}
       />
     </div>
   );

--- a/apps/web/vibes/soul/examples/sections/products-list-section/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/products-list-section/warm.tsx
@@ -11,26 +11,34 @@ export default async function Preview({
   const parsedParams = cache.parse(await searchParams);
   const { [compareParamName]: compare, [sortParamName]: sort, ...filterParams } = parsedParams;
 
-  const productsPromise = getProducts('Warm', filterParams);
   const filters = getFilters('Warm');
   const sortOptions = getSortOptions();
   const breadcrumbs = getBreadcrumbs('Warm');
+
+  const productsList = {
+    title: 'Handle Bags',
+    products: getProducts('Warm', filterParams),
+    emptyStateSubtitle: 'Change your filters to see more products',
+    emptyStateTitle: 'No products found',
+  };
 
   return (
     <div className="p-6">
       <ProductsListSection
         breadcrumbs={breadcrumbs}
         compareParamName={compareParamName}
-        compareProducts={productsPromise.then((products) =>
+        compareProducts={productsList.products.then((products) =>
           products.filter((product) => compare?.includes(product.id)),
         )}
+        emptyStateSubtitle={productsList.emptyStateSubtitle}
+        emptyStateTitle={productsList.emptyStateTitle}
         filters={filters}
         paginationInfo={{ startCursor: '1', endCursor: '10' }}
-        products={productsPromise}
+        products={productsList.products}
         sortOptions={sortOptions}
         sortParamName={sortParamName}
-        title="Handle Bags"
-        totalCount={productsPromise.then((products) => products.length)}
+        title={productsList.title}
+        totalCount={productsList.products.then((products) => products.length)}
       />
     </div>
   );

--- a/apps/web/vibes/soul/primitives/products-carousel/index.tsx
+++ b/apps/web/vibes/soul/primitives/products-carousel/index.tsx
@@ -19,11 +19,12 @@ export type CarouselProduct = CardProduct;
 interface Props {
   products: Streamable<CarouselProduct[]>;
   className?: string;
-  emptyStateTitle?: string;
-  emptyStateSubtitle?: string;
+  emptyStateTitle?: Streamable<string | null>;
+  emptyStateSubtitle?: Streamable<string | null>;
   scrollbarLabel?: string;
   previousLabel?: string;
   nextLabel?: string;
+  placeholderCount?: number;
 }
 
 export function ProductsCarousel({
@@ -34,15 +35,20 @@ export function ProductsCarousel({
   scrollbarLabel,
   previousLabel,
   nextLabel,
+  placeholderCount = 8,
 }: Props) {
   return (
-    <Stream fallback={<ProductsCarouselSkeleton pending />} value={streamableProducts}>
+    <Stream
+      fallback={<ProductsCarouselSkeleton placeholderCount={placeholderCount} pending />}
+      value={streamableProducts}
+    >
       {(products) => {
         if (products.length === 0) {
           return (
             <ProductsCarouselEmptyState
               emptyStateSubtitle={emptyStateSubtitle}
               emptyStateTitle={emptyStateTitle}
+              placeholderCount={placeholderCount}
             />
           );
         }
@@ -72,17 +78,17 @@ export function ProductsCarousel({
 
 export function ProductsCarouselSkeleton({
   className,
-  count = 8,
+  placeholderCount = 8,
   pending = false,
 }: {
   className?: string;
-  count?: number;
+  placeholderCount?: number;
   pending?: boolean;
 }) {
   return (
     <Carousel className={className} data-pending={pending ? '' : undefined}>
       <CarouselContent className="mb-10">
-        {Array.from({ length: count }).map((_, index) => (
+        {Array.from({ length: placeholderCount }).map((_, index) => (
           <CarouselItem
             className="basis-full @md:basis-1/2 @lg:basis-1/3 @2xl:basis-1/4"
             key={index}
@@ -98,21 +104,21 @@ export function ProductsCarouselSkeleton({
 
 export function ProductsCarouselEmptyState({
   className,
-  count = 8,
+  placeholderCount = 8,
   emptyStateTitle,
   emptyStateSubtitle,
 }: {
   className?: string;
-  count?: number;
-  emptyStateTitle?: string;
-  emptyStateSubtitle?: string;
+  placeholderCount?: number;
+  emptyStateTitle?: Streamable<string | null>;
+  emptyStateSubtitle?: Streamable<string | null>;
 }) {
   return (
     <Carousel className={clsx('relative', className)}>
       <CarouselContent
         className={clsx('mb-10 [mask-image:linear-gradient(to_bottom,_black_0%,_transparent_90%)]')}
       >
-        {Array.from({ length: count }).map((_, index) => (
+        {Array.from({ length: placeholderCount }).map((_, index) => (
           <CarouselItem
             className="basis-full @md:basis-1/2 @lg:basis-1/3 @2xl:basis-1/4"
             key={index}

--- a/apps/web/vibes/soul/primitives/products-list/index.tsx
+++ b/apps/web/vibes/soul/primitives/products-list/index.tsx
@@ -19,8 +19,9 @@ interface Props {
   compareAction?: React.ComponentProps<'form'>['action'];
   compareLabel?: string;
   compareParamName?: string;
-  emptyStateTitle?: string;
-  emptyStateSubtitle?: string;
+  emptyStateTitle?: Streamable<string | null>;
+  emptyStateSubtitle?: Streamable<string | null>;
+  placeholderCount?: number;
 }
 
 export function ProductsList({
@@ -33,16 +34,21 @@ export function ProductsList({
   compareParamName,
   emptyStateTitle,
   emptyStateSubtitle,
+  placeholderCount = 6,
 }: Props) {
   return (
     <>
-      <Stream fallback={<ProductsListSkeleton pending />} value={streamableProducts}>
+      <Stream
+        fallback={<ProductsListSkeleton pending placeholderCount={placeholderCount} />}
+        value={streamableProducts}
+      >
         {(products) => {
           if (products.length === 0) {
             return (
               <ProductsListEmptyState
                 emptyStateSubtitle={emptyStateSubtitle}
                 emptyStateTitle={emptyStateTitle}
+                placeholderCount={placeholderCount}
               />
             );
           }
@@ -82,17 +88,17 @@ export function ProductsList({
 
 export function ProductsListSkeleton({
   className,
-  count = 6,
+  placeholderCount = 6,
   pending = false,
 }: {
   className?: string;
-  count?: number;
+  placeholderCount?: number;
   pending?: boolean;
 }) {
   return (
     <div className={clsx('w-full @container', className)} data-pending={pending ? '' : undefined}>
       <div className="mx-auto grid grid-cols-1 gap-x-4 gap-y-6 @sm:grid-cols-2 @2xl:grid-cols-3 @2xl:gap-x-5 @2xl:gap-y-8 @5xl:grid-cols-4 @7xl:grid-cols-5">
-        {Array.from({ length: count }).map((_, index) => (
+        {Array.from({ length: placeholderCount }).map((_, index) => (
           <ProductCardSkeleton key={index} />
         ))}
       </div>
@@ -102,14 +108,14 @@ export function ProductsListSkeleton({
 
 export function ProductsListEmptyState({
   className,
-  count = 6,
+  placeholderCount = 6,
   emptyStateTitle,
   emptyStateSubtitle,
 }: {
   className?: string;
-  count?: number;
-  emptyStateTitle?: string;
-  emptyStateSubtitle?: string;
+  placeholderCount?: number;
+  emptyStateTitle?: Streamable<string | null>;
+  emptyStateSubtitle?: Streamable<string | null>;
 }) {
   return (
     <div className={clsx('relative w-full @container', className)}>
@@ -118,7 +124,7 @@ export function ProductsListEmptyState({
           'mx-auto grid grid-cols-1 gap-x-4 gap-y-6 [mask-image:linear-gradient(to_bottom,_black_0%,_transparent_90%)] @sm:grid-cols-2 @2xl:grid-cols-3 @2xl:gap-x-5 @2xl:gap-y-8 @5xl:grid-cols-4 @7xl:grid-cols-5',
         )}
       >
-        {Array.from({ length: count }).map((_, index) => (
+        {Array.from({ length: placeholderCount }).map((_, index) => (
           <ProductCardSkeleton key={index} />
         ))}
       </div>

--- a/apps/web/vibes/soul/sections/featured-products-carousel/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-products-carousel/index.tsx
@@ -12,8 +12,9 @@ interface Props {
   description?: string;
   cta?: Link;
   products: Streamable<CarouselProduct[]>;
-  emptyStateTitle?: string;
-  emptyStateSubtitle?: string;
+  emptyStateTitle?: Streamable<string | null>;
+  emptyStateSubtitle?: Streamable<string | null>;
+  placeholderCount?: number;
   scrollbarLabel?: string;
   previousLabel?: string;
   nextLabel?: string;
@@ -26,6 +27,7 @@ export function FeaturedProductsCarousel({
   products,
   emptyStateTitle,
   emptyStateSubtitle,
+  placeholderCount,
   scrollbarLabel,
   previousLabel,
   nextLabel,
@@ -52,6 +54,7 @@ export function FeaturedProductsCarousel({
             emptyStateSubtitle={emptyStateSubtitle}
             emptyStateTitle={emptyStateTitle}
             nextLabel={nextLabel}
+            placeholderCount={placeholderCount}
             previousLabel={previousLabel}
             products={products}
             scrollbarLabel={scrollbarLabel}

--- a/apps/web/vibes/soul/sections/featured-products-list/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-products-list/index.tsx
@@ -13,8 +13,9 @@ interface Props {
   description?: string;
   cta?: Link;
   products: Streamable<ListProduct[]>;
-  emptyStateTitle?: string;
-  emptyStateSubtitle?: string;
+  emptyStateTitle?: Streamable<string | null>;
+  emptyStateSubtitle?: Streamable<string | null>;
+  placeholderCount?: number;
 }
 
 export function FeaturedProductsList({
@@ -24,6 +25,7 @@ export function FeaturedProductsList({
   products,
   emptyStateTitle,
   emptyStateSubtitle,
+  placeholderCount,
 }: Props) {
   return (
     <StickySidebarLayout
@@ -52,6 +54,7 @@ export function FeaturedProductsList({
           className="flex-1"
           emptyStateSubtitle={emptyStateSubtitle}
           emptyStateTitle={emptyStateTitle}
+          placeholderCount={placeholderCount}
           products={products}
         />
       </div>

--- a/apps/web/vibes/soul/sections/products-list-section/index.tsx
+++ b/apps/web/vibes/soul/sections/products-list-section/index.tsx
@@ -31,6 +31,9 @@ interface Props {
   sortLabel?: string;
   sortParamName?: string;
   compareParamName?: string;
+  emptyStateSubtitle?: Streamable<string | null>;
+  emptyStateTitle?: Streamable<string | null>;
+  placeholderCount?: number;
 }
 
 export function ProductsListSection({
@@ -49,6 +52,9 @@ export function ProductsListSection({
   sortLabel,
   sortParamName,
   compareParamName,
+  emptyStateSubtitle,
+  emptyStateTitle,
+  placeholderCount = 8,
 }: Props) {
   return (
     <ProductListTransitionProvider>
@@ -98,6 +104,9 @@ export function ProductsListSection({
                 compareLabel={compareLabel}
                 compareParamName={compareParamName}
                 compareProducts={compareProducts}
+                emptyStateSubtitle={emptyStateSubtitle}
+                emptyStateTitle={emptyStateTitle}
+                placeholderCount={placeholderCount}
                 products={products}
                 showCompare
               />


### PR DESCRIPTION
## What/Why
- Adds `count` prop to `ProductList` so sections that use this component can render a custom number of empty state cards 
- Adds `emptyStateTitle` and `emptyStateDescription` to `ProductsListSection`

## Testing
https://github.com/user-attachments/assets/bdfb2cb7-ecc0-4377-a30d-837e3528104f

