### PR TITLE
feat: add accessible props to ProductDetail

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -25,6 +25,7 @@ interface Props<F extends Field> {
   action: ProductDetailFormAction<F>;
   fields: Streamable<F[]>;
   ctaLabel?: string;
+  quantityLabel?: string;
 }
 
 export function ProductDetail<F extends Field>({
@@ -33,6 +34,7 @@ export function ProductDetail<F extends Field>({
   fields: streamableFields,
   breadcrumbs: streamableBreadcrumbs,
   ctaLabel,
+  quantityLabel,
 }: Props<F>) {
   return (
     <section className="@container">
@@ -98,6 +100,7 @@ export function ProductDetail<F extends Field>({
                         ctaLabel={ctaLabel}
                         fields={fields}
                         productId={product.id}
+                        quantityLabel={quantityLabel}
                       />
                     )}
                   </Stream>

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -26,6 +26,8 @@ interface Props<F extends Field> {
   fields: Streamable<F[]>;
   ctaLabel?: string;
   quantityLabel?: string;
+  incrementLabel?: string;
+  decrementLabel?: string;
 }
 
 export function ProductDetail<F extends Field>({
@@ -35,6 +37,8 @@ export function ProductDetail<F extends Field>({
   breadcrumbs: streamableBreadcrumbs,
   ctaLabel,
   quantityLabel,
+  incrementLabel,
+  decrementLabel,
 }: Props<F>) {
   return (
     <section className="@container">
@@ -98,7 +102,9 @@ export function ProductDetail<F extends Field>({
                       <ProductDetailForm
                         action={action}
                         ctaLabel={ctaLabel}
+                        decrementLabel={decrementLabel}
                         fields={fields}
+                        incrementLabel={incrementLabel}
                         productId={product.id}
                         quantityLabel={quantityLabel}
                       />

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -24,6 +24,7 @@ interface Props<F extends Field> {
   product: Streamable<ProductDetailProduct | null>;
   action: ProductDetailFormAction<F>;
   fields: Streamable<F[]>;
+  ctaLabel?: string;
 }
 
 export function ProductDetail<F extends Field>({
@@ -31,6 +32,7 @@ export function ProductDetail<F extends Field>({
   action,
   fields: streamableFields,
   breadcrumbs: streamableBreadcrumbs,
+  ctaLabel,
 }: Props<F>) {
   return (
     <section className="@container">
@@ -91,7 +93,12 @@ export function ProductDetail<F extends Field>({
 
                   <Stream fallback={<ProductDetailFormSkeleton />} value={streamableFields}>
                     {(fields) => (
-                      <ProductDetailForm action={action} fields={fields} productId={product.id} />
+                      <ProductDetailForm
+                        action={action}
+                        ctaLabel={ctaLabel}
+                        fields={fields}
+                        productId={product.id}
+                      />
                     )}
                   </Stream>
                 </div>

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -41,6 +41,8 @@ interface Props<F extends Field> {
   productId: string;
   ctaLabel?: string;
   quantityLabel?: string;
+  incrementLabel?: string;
+  decrementLabel?: string;
 }
 
 export function ProductDetailForm<F extends Field>({
@@ -49,6 +51,8 @@ export function ProductDetailForm<F extends Field>({
   productId,
   ctaLabel = 'Add to cart',
   quantityLabel = 'Quantity',
+  incrementLabel = 'Increase quantity',
+  decrementLabel = 'Decrease quantity',
 }: Props<F>) {
   const [params] = useQueryStates(
     fields.reduce<Record<string, typeof parseAsString>>(
@@ -104,7 +108,9 @@ export function ProductDetailForm<F extends Field>({
           <div className="flex gap-x-3 pt-3">
             <NumberInput
               aria-label={quantityLabel}
+              decrementLabel={decrementLabel}
               id={formFields.quantity.id}
+              incrementLabel={incrementLabel}
               min={1}
               name={formFields.quantity.name}
               onBlur={quantityControl.blur}

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -40,6 +40,7 @@ interface Props<F extends Field> {
   action: ProductDetailFormAction<F>;
   productId: string;
   ctaLabel?: string;
+  quantityLabel?: string;
 }
 
 export function ProductDetailForm<F extends Field>({
@@ -47,6 +48,7 @@ export function ProductDetailForm<F extends Field>({
   fields,
   productId,
   ctaLabel = 'Add to cart',
+  quantityLabel = 'Quantity',
 }: Props<F>) {
   const [params] = useQueryStates(
     fields.reduce<Record<string, typeof parseAsString>>(
@@ -101,8 +103,8 @@ export function ProductDetailForm<F extends Field>({
           })}
           <div className="flex gap-x-3 pt-3">
             <NumberInput
+              aria-label={quantityLabel}
               id={formFields.quantity.id}
-              label=""
               min={1}
               name={formFields.quantity.name}
               onBlur={quantityControl.blur}


### PR DESCRIPTION
Adds `quantityLabel` prop to ProductDetail that is then forwarded to form and set as an `aria-label` to the quantity field since we don't have a visible label.

![Screenshot 2024-12-12 at 7 28 27 PM](https://github.com/user-attachments/assets/e1c393e7-63db-49c1-b59c-085a9f56fb07)
