### PR TITLE
feat: show toasts on successfully adding a product

### DIFF
--- a/apps/web/vibes/soul/examples/sections/product-detail/action.ts
+++ b/apps/web/vibes/soul/examples/sections/product-detail/action.ts
@@ -107,5 +107,6 @@ export async function action(
   return {
     fields: prevState.fields,
     lastResult: submission.reply({}),
+    successMessage: 'Product(s) added to cart!',
   };
 }

--- a/apps/web/vibes/soul/primitives/alert/index.tsx
+++ b/apps/web/vibes/soul/primitives/alert/index.tsx
@@ -1,11 +1,12 @@
 import { clsx } from 'clsx';
 import { X } from 'lucide-react';
+import { ReactNode } from 'react';
 
 import { Button } from '@/vibes/soul/primitives/button';
 
 interface Props {
   variant: 'success' | 'warning' | 'error' | 'info';
-  message: string;
+  message: ReactNode;
   description?: string;
   dismissLabel?: string;
   action?: {

--- a/apps/web/vibes/soul/primitives/toaster/index.tsx
+++ b/apps/web/vibes/soul/primitives/toaster/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ReactNode } from 'react';
 import { Toaster as Sonner, toast as SonnerToast } from 'sonner';
 
 import { Alert } from '@/vibes/soul/primitives/alert';
@@ -31,7 +32,7 @@ export const Toaster = ({ ...props }: ToasterProps) => {
 };
 
 export const toast = {
-  success: (message: string, options?: ToastOptions) => {
+  success: (message: ReactNode, options?: ToastOptions) => {
     const position = options?.position;
 
     const toastId = SonnerToast(
@@ -44,7 +45,7 @@ export const toast = {
       { position },
     );
   },
-  error: (message: string, options?: ToastOptions) => {
+  error: (message: ReactNode, options?: ToastOptions) => {
     const position = options?.position;
 
     const toastId = SonnerToast(
@@ -57,7 +58,7 @@ export const toast = {
       { position },
     );
   },
-  warning: (message: string, options?: ToastOptions) => {
+  warning: (message: ReactNode, options?: ToastOptions) => {
     const position = options?.position;
 
     const toastId = SonnerToast(
@@ -70,7 +71,7 @@ export const toast = {
       { position },
     );
   },
-  info: (message: string, options?: ToastOptions) => {
+  info: (message: ReactNode, options?: ToastOptions) => {
     const position = options?.position;
 
     const toastId = SonnerToast(

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -28,7 +28,6 @@ interface Props<F extends Field> {
   quantityLabel?: string;
   incrementLabel?: string;
   decrementLabel?: string;
-  successMessage?: string;
 }
 
 export function ProductDetail<F extends Field>({
@@ -40,7 +39,6 @@ export function ProductDetail<F extends Field>({
   quantityLabel,
   incrementLabel,
   decrementLabel,
-  successMessage,
 }: Props<F>) {
   return (
     <section className="@container">
@@ -109,7 +107,6 @@ export function ProductDetail<F extends Field>({
                         incrementLabel={incrementLabel}
                         productId={product.id}
                         quantityLabel={quantityLabel}
-                        successMessage={successMessage}
                       />
                     )}
                   </Stream>

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -28,6 +28,7 @@ interface Props<F extends Field> {
   quantityLabel?: string;
   incrementLabel?: string;
   decrementLabel?: string;
+  successMessage?: string;
 }
 
 export function ProductDetail<F extends Field>({
@@ -39,6 +40,7 @@ export function ProductDetail<F extends Field>({
   quantityLabel,
   incrementLabel,
   decrementLabel,
+  successMessage,
 }: Props<F>) {
   return (
     <section className="@container">
@@ -107,6 +109,7 @@ export function ProductDetail<F extends Field>({
                         incrementLabel={incrementLabel}
                         productId={product.id}
                         quantityLabel={quantityLabel}
+                        successMessage={successMessage}
                       />
                     )}
                   </Stream>

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -10,7 +10,7 @@ import {
 } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { parseAsString, useQueryState, useQueryStates } from 'nuqs';
-import { useActionState, useCallback } from 'react';
+import { useActionState, useCallback, useEffect } from 'react';
 import { useFormStatus } from 'react-dom';
 import { z } from 'zod';
 
@@ -23,6 +23,7 @@ import { RadioGroup } from '@/vibes/soul/form/radio-group';
 import { Select } from '@/vibes/soul/form/select';
 import { SwatchRadioGroup } from '@/vibes/soul/form/swatch-radio-group';
 import { Button } from '@/vibes/soul/primitives/button';
+import { toast } from '@/vibes/soul/primitives/toaster';
 
 import { Field, schema, SchemaRawShape } from './schema';
 
@@ -43,6 +44,7 @@ interface Props<F extends Field> {
   quantityLabel?: string;
   incrementLabel?: string;
   decrementLabel?: string;
+  successMessage?: string;
 }
 
 export function ProductDetailForm<F extends Field>({
@@ -53,6 +55,7 @@ export function ProductDetailForm<F extends Field>({
   quantityLabel = 'Quantity',
   incrementLabel = 'Increase quantity',
   decrementLabel = 'Decrease quantity',
+  successMessage = 'Product(s) succesfully added to cart!',
 }: Props<F>) {
   const [params] = useQueryStates(
     fields.reduce<Record<string, typeof parseAsString>>(
@@ -63,6 +66,7 @@ export function ProductDetailForm<F extends Field>({
     ),
     { shallow: false },
   );
+
   const defaultValue = fields.reduce<{
     [Key in keyof SchemaRawShape]?: z.infer<SchemaRawShape[Key]>;
   }>(
@@ -72,10 +76,18 @@ export function ProductDetailForm<F extends Field>({
     }),
     { quantity: 1 },
   );
+
   const [{ lastResult }, formAction] = useActionState(action, {
     fields,
     lastResult: null,
   });
+
+  useEffect(() => {
+    if (lastResult?.status === 'success') {
+      toast.success(successMessage);
+    }
+  }, [lastResult, successMessage]);
+
   const [form, formFields] = useForm({
     lastResult,
     constraint: getZodConstraint(schema(fields)),
@@ -87,6 +99,7 @@ export function ProductDetailForm<F extends Field>({
     shouldValidate: 'onSubmit',
     shouldRevalidate: 'onInput',
   });
+
   const quantityControl = useInputControl(formFields.quantity);
 
   return (


### PR DESCRIPTION
This will show a toast of a simple string when product is added successfully. We still need to think about how to pass in string interpolation so that we can render a more custom message with a link that understand the quantity added.

![Screenshot 2024-12-13 at 2 02 07 PM](https://github.com/user-attachments/assets/33e71a1d-f131-42a8-b730-a837aab48e73)
