### PR TITLE
feat: avoid layout shift when breadcrumbs are empty

### DIFF
--- a/apps/web/vibes/soul/primitives/animated-link/index.tsx
+++ b/apps/web/vibes/soul/primitives/animated-link/index.tsx
@@ -14,7 +14,7 @@ export function AnimatedLink({ link, label, className }: AnimatedLinkProps) {
   return (
     <Link
       className={clsx(
-        'text-surface-foreground origin-left pb-0.5 font-semibold transition-[background-size] duration-300 [background:linear-gradient(0deg,hsl(var(--primary)),hsl(var(--primary)))_no-repeat_left_bottom_/_0_2px] hover:bg-[size:100%_2px] focus:outline-none focus-visible:bg-[size:100%_2px]',
+        'origin-left font-semibold leading-normal text-foreground transition-[background-size] duration-300 [background:linear-gradient(0deg,hsl(var(--primary)),hsl(var(--primary)))_no-repeat_left_bottom_/_0_2px] hover:bg-[size:100%_2px] focus:outline-none focus-visible:bg-[size:100%_2px]',
         className,
       )}
       href={link.href}

--- a/apps/web/vibes/soul/primitives/breadcrumbs/index.tsx
+++ b/apps/web/vibes/soul/primitives/breadcrumbs/index.tsx
@@ -14,6 +14,10 @@ export interface BreadcrumbsProps {
 }
 
 export function Breadcrumbs({ breadcrumbs, className }: BreadcrumbsProps) {
+  if (breadcrumbs.length === 0) {
+    return <div className={clsx('min-h-[1lh]', className)} />;
+  }
+
   return (
     <nav aria-label="breadcrumb" className={clsx(className)}>
       <ol className="flex flex-wrap items-center gap-x-1.5 text-sm @xl:text-base">
@@ -48,7 +52,10 @@ export function Breadcrumbs({ breadcrumbs, className }: BreadcrumbsProps) {
 export function BreadcrumbsSkeleton({ className }: { className?: string }) {
   return (
     <div
-      className={clsx('flex animate-pulse flex-wrap items-center gap-x-1.5 text-base', className)}
+      className={clsx(
+        'flex min-h-[1lh] animate-pulse flex-wrap items-center gap-x-1.5 text-base',
+        className,
+      )}
     >
       <div className="flex h-[1lh] items-center">
         <span className="block h-[1.25ex] w-[4ch] rounded bg-contrast-100" />


### PR DESCRIPTION
## What/Why
- Avoids layout shift when no breadcrumbs are present by adding an empty `div`
- Removes padding from animate links to avoid extra height being added

## Testing

https://github.com/user-attachments/assets/0bcb17b5-3f4e-497c-ab63-07fdf0065361

