### PR TITLE
fix: pass in server side default values for hydration issue

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -102,6 +102,7 @@ export function ProductDetailForm<F extends Field>({
                 formField={formFields[field.name]!}
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 key={formFields[field.name]!.id}
+                defaultValue={defaultValue[field.name]}
               />
             );
           })}
@@ -139,9 +140,11 @@ function SubmitButton({ children }: { children: React.ReactNode }) {
 function FormField({
   field,
   formField,
+  defaultValue,
 }: {
   field: Field;
   formField: FieldMetadata<string | number | boolean | Date | undefined>;
+  defaultValue?: string | number;
 }) {
   const controls = useInputControl(formField);
   const [, setParam] = useQueryState(field.name, parseAsString.withOptions({ shallow: false }));
@@ -167,6 +170,7 @@ function FormField({
           onFocus={controls.focus}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue}
         />
       );
 
@@ -182,6 +186,7 @@ function FormField({
           onFocus={controls.focus}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue}
         />
       );
 
@@ -197,6 +202,7 @@ function FormField({
           onFocus={controls.focus}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue}
         />
       );
 
@@ -213,6 +219,7 @@ function FormField({
           options={field.options}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue?.toString()}
         />
       );
 
@@ -229,6 +236,7 @@ function FormField({
           options={field.options}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue?.toString()}
         />
       );
 
@@ -245,6 +253,7 @@ function FormField({
           options={field.options}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue?.toString()}
         />
       );
 
@@ -261,6 +270,7 @@ function FormField({
           options={field.options}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue?.toString()}
         />
       );
 
@@ -277,6 +287,7 @@ function FormField({
           options={field.options}
           required={formField.required}
           value={controls.value}
+          defaultValue={defaultValue?.toString()}
         />
       );
   }


### PR DESCRIPTION
In ProductDetail, during server render, some of the Radix primitives get set as unchecked/unselected even when we know that these fields should have a value. During hydration, we get an error because aria attributes/params mismatch once values set.

This fix is to set a default value so that this mismatch is prevented. 

My testing included using non radix form elements which rendered fine, probably because properties don't change. Default values in the form get set correctly on static rendering but for dynamic rendering we don't see these for some reason.

Is it expected that the `useForm` hook ignores these values during server render?

I'm open to suggestions.