### PR TITLE
feat: add default props and optimistic update to account settings

### DIFF
--- a/apps/web/vibes/soul/examples/sections/account-settings-section/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/account-settings-section/actions.ts
@@ -5,23 +5,28 @@ import {
   changePasswordSchema,
   updateAccountSchema,
 } from '@/vibes/soul/sections/account-settings-section/schema';
+import { UpdateAccountAction } from '@/vibes/soul/sections/account-settings-section/update-account-form';
 
-export async function updateAccountAction(lastResult: SubmissionResult | null, formData: FormData) {
+export const updateAccountAction: UpdateAccountAction = async (prevState, formData) => {
   'use server';
 
   const submission = parseWithZod(formData, { schema: updateAccountSchema });
 
   if (submission.status !== 'success') {
-    return submission.reply({ formErrors: ['Boom!'] });
+    return {
+      account: prevState.account,
+      lastResult: submission.reply({ formErrors: ['Boom!'] }),
+    };
   }
 
-  // Simulate a network request
   await new Promise((resolve) => setTimeout(resolve, 1000));
 
-  // const user = await logIn(submission.value)
-
-  return submission.reply({ resetForm: true });
-}
+  return {
+    account: submission.value,
+    successMessage: 'Account updated!',
+    lastResult: submission.reply(),
+  };
+};
 
 export async function changePasswordAction(
   lastResult: SubmissionResult | null,
@@ -40,5 +45,5 @@ export async function changePasswordAction(
 
   // const user = await logIn(submission.value)
 
-  return submission.reply({ resetForm: true });
+  return submission.reply();
 }

--- a/apps/web/vibes/soul/examples/sections/account-settings-section/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/account-settings-section/index.tsx
@@ -4,8 +4,8 @@ import { AccountSettingsSection } from '@/vibes/soul/sections/account-settings-s
 import { changePasswordAction, updateAccountAction } from './actions';
 
 const links = [
-  { href: '#', label: 'Orders' },
-  { href: '#', label: 'Addresses' },
+  { href: '/preview/soul/order-list-section-electric-example', label: 'Orders' },
+  { href: '/preview/soul/address-list-section-example', label: 'Addresses' },
   { href: '/preview/soul/account-settings-section-example', label: 'Account' },
 ];
 
@@ -13,6 +13,7 @@ export default function Preview() {
   return (
     <AccountLayout links={links}>
       <AccountSettingsSection
+        account={{ firstName: '', lastName: '', email: '' }}
         changePasswordAction={changePasswordAction}
         updateAccountAction={updateAccountAction}
       />

--- a/apps/web/vibes/soul/examples/sections/address-list-section/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/address-list-section/index.tsx
@@ -1,3 +1,4 @@
+import { AccountLayout } from '@/vibes/soul/sections/account-layout';
 import { Address, AddressListSection } from '@/vibes/soul/sections/address-list-section';
 
 import { addressAction } from './actions';
@@ -26,14 +27,20 @@ const addresses: Address[] = [
   },
 ];
 
+const links = [
+  { href: '/preview/soul/order-list-section-electric-example', label: 'Orders' },
+  { href: '/preview/soul/address-list-section-example', label: 'Addresses' },
+  { href: '/preview/soul/account-settings-section-example', label: 'Account' },
+];
+
 export default function Preview() {
   return (
-    <div className="m-auto max-w-screen-xl p-5">
+    <AccountLayout links={links}>
       <AddressListSection
         addressAction={addressAction}
         addresses={addresses}
         defaultAddressId="1"
       />
-    </div>
+    </AccountLayout>
   );
 }

--- a/apps/web/vibes/soul/examples/sections/order-list-section/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/order-list-section/electric.tsx
@@ -56,9 +56,9 @@ const orders = [
 ];
 
 const links = [
-  { href: '#', label: 'Orders' },
-  { href: '#', label: 'Addresses' },
-  { href: '#', label: 'Account' },
+  { href: '/preview/soul/order-list-section-electric-example', label: 'Orders' },
+  { href: '/preview/soul/address-list-section-example', label: 'Addresses' },
+  { href: '/preview/soul/account-settings-section-example', label: 'Account' },
 ];
 
 export default function Preview() {

--- a/apps/web/vibes/soul/sections/account-settings-section/index.tsx
+++ b/apps/web/vibes/soul/sections/account-settings-section/index.tsx
@@ -1,8 +1,9 @@
 import { ChangePasswordAction, ChangePasswordForm } from './change-password-form';
-import { UpdateAccountAction, UpdateAccountForm } from './update-account-form';
+import { Account, UpdateAccountAction, UpdateAccountForm } from './update-account-form';
 
 interface Props {
   title?: string;
+  account: Account;
   updateAccountAction: UpdateAccountAction;
   updateAccountSubmitLabel?: string;
   changePasswordTitle?: string;
@@ -12,6 +13,7 @@ interface Props {
 
 export function AccountSettingsSection({
   title = 'Account Settings',
+  account,
   updateAccountAction,
   updateAccountSubmitLabel,
   changePasswordTitle = 'Change Password',
@@ -25,6 +27,7 @@ export function AccountSettingsSection({
           <div className="pb-12">
             <h1 className="mb-10 text-4xl font-medium leading-none @xl:text-4xl">{title}</h1>
             <UpdateAccountForm
+              account={account}
               action={updateAccountAction}
               submitLabel={updateAccountSubmitLabel}
             />

--- a/apps/web/vibes/soul/sections/account-settings-section/schema.ts
+++ b/apps/web/vibes/soul/sections/account-settings-section/schema.ts
@@ -4,6 +4,7 @@ export const updateAccountSchema = z.object({
   firstName: z.string().min(2, { message: 'Name must be at least 2 characters long.' }).trim(),
   lastName: z.string().min(2, { message: 'Name must be at least 2 characters long.' }).trim(),
   email: z.string().email({ message: 'Please enter a valid email.' }).trim(),
+  company: z.string().trim().optional(),
 });
 
 export const changePasswordSchema = z


### PR DESCRIPTION
### What/Why?

- Adds default values to be passed into the update account settings form.
- Adds a company field to the form
- Uses optimistic updates when submitting the update customer form action.
- Updates some examples to use the `AccountLayout` plus real links (to prevent duplicate React keys warning).

### Testing
![Screenshot 2024-12-16 at 14 31 26](https://github.com/user-attachments/assets/7c35936c-362f-4149-a627-ad6b600f276f)



https://github.com/user-attachments/assets/10427720-3359-4096-9114-b993badeeba4


