### PR TITLE
feat: upgrade nuqs to latest version

### DIFF
--- a/apps/web/app/(preview)/layout.tsx
+++ b/apps/web/app/(preview)/layout.tsx
@@ -1,4 +1,6 @@
 import './style/globals.css';
+import { NuqsAdapter } from 'nuqs/adapters/next/app';
+
 import { Toaster } from '@/vibes/soul/primitives/toaster';
 
 import { ZoomListener } from '../zoom-listener';
@@ -18,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         We want to make it so that each vibe has its own preview 
         layout. */}
         <Toaster position="top-right" />
-        {children}
+        <NuqsAdapter>{children}</NuqsAdapter>
       </body>
     </html>
   );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -64,7 +64,7 @@
     "next-mdx-remote": "0.0.0-canary-20240321205249",
     "next-sitemap": "^4.2.3",
     "next-themes": "^0.2.1",
-    "nuqs": "^1.20.0",
+    "nuqs": "^2.2.3",
     "posthog-js": "^1.138.1",
     "pretty-bytes": "^6.1.1",
     "prismjs": "^1.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,7 +35,7 @@ importers:
         version: 3.6.3
       '@docsearch/react':
         specifier: ^3.6.1
-        version: 3.6.3(@algolia/client-search@5.12.0)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)(search-insights@2.17.2)(types-react@19.0.0-rc.1)
+        version: 3.6.3(@algolia/client-search@5.17.1)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)(search-insights@2.17.3)(types-react@19.0.0-rc.1)
       '@hookform/resolvers':
         specifier: ^3.5.0
         version: 3.9.1(react-hook-form@7.53.1)
@@ -53,7 +53,7 @@ importers:
         version: 3.1.0(react@19.0.0-rc-603e6108-20241029)(types-react@19.0.0-rc.1)
       '@nextui-org/date-input':
         specifier: ^2.1.3
-        version: 2.1.4(@nextui-org/system@2.2.6)(@nextui-org/theme@2.2.11)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
+        version: 2.1.4(@nextui-org/system@2.4.4)(@nextui-org/theme@2.4.3)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
       '@radix-ui/react-accordion':
         specifier: 1.2.1
         version: 1.2.1(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)(types-react-dom@19.0.0-rc.1)(types-react@19.0.0-rc.1)
@@ -178,8 +178,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1(next@15.0.2)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
       nuqs:
-        specifier: ^1.20.0
-        version: 1.20.0(next@15.0.2)
+        specifier: ^2.2.3
+        version: 2.2.3(next@15.0.2)(react@19.0.0-rc-603e6108-20241029)
       posthog-js:
         specifier: ^1.138.1
         version: 1.180.0
@@ -276,7 +276,7 @@ importers:
         version: 2.18.3
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.5.0
-        version: 8.12.2(@typescript-eslint/parser@8.12.2)(eslint@8.57.1)(typescript@5.6.3)
+        version: 8.12.2(@typescript-eslint/parser@8.18.1)(eslint@8.57.1)(typescript@5.6.3)
       autoprefixer:
         specifier: ^10.0.1
         version: 10.4.20(postcss@8.4.47)
@@ -316,57 +316,57 @@ importers:
 
 packages:
 
-  /@algolia/autocomplete-core@1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)(search-insights@2.17.2):
+  /@algolia/autocomplete-core@1.9.3(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)(search-insights@2.17.3):
     resolution: {integrity: sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==}
     dependencies:
-      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)(search-insights@2.17.2)
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)
+      '@algolia/autocomplete-plugin-algolia-insights': 1.9.3(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
       - search-insights
     dev: false
 
-  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)(search-insights@2.17.2):
+  /@algolia/autocomplete-plugin-algolia-insights@1.9.3(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)(search-insights@2.17.3):
     resolution: {integrity: sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==}
     peerDependencies:
       search-insights: '>= 1 < 3'
     dependencies:
-      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)
-      search-insights: 2.17.2
+      '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)
+      search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
       - algoliasearch
     dev: false
 
-  /@algolia/autocomplete-preset-algolia@1.17.6(@algolia/client-search@5.12.0)(algoliasearch@5.12.0):
+  /@algolia/autocomplete-preset-algolia@1.17.6(@algolia/client-search@5.17.1)(algoliasearch@5.12.0):
     resolution: {integrity: sha512-Cvg5JENdSCMuClwhJ1ON1/jSuojaYMiUW2KePm18IkdCzPJj/NXojaOxw58RFtQFpJgfVW8h2E8mEoDtLlMdeA==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
     dependencies:
-      '@algolia/autocomplete-shared': 1.17.6(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)
-      '@algolia/client-search': 5.12.0
+      '@algolia/autocomplete-shared': 1.17.6(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)
+      '@algolia/client-search': 5.17.1
       algoliasearch: 5.12.0
     dev: false
 
-  /@algolia/autocomplete-shared@1.17.6(@algolia/client-search@5.12.0)(algoliasearch@5.12.0):
+  /@algolia/autocomplete-shared@1.17.6(@algolia/client-search@5.17.1)(algoliasearch@5.12.0):
     resolution: {integrity: sha512-aq/3V9E00Tw2GC/PqgyPGXtqJUlVc17v4cn1EUhSc+O/4zd04Uwb3UmPm8KDaYQQOrkt1lwvCj2vG2wRE5IKhw==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
     dependencies:
-      '@algolia/client-search': 5.12.0
+      '@algolia/client-search': 5.17.1
       algoliasearch: 5.12.0
     dev: false
 
-  /@algolia/autocomplete-shared@1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0):
+  /@algolia/autocomplete-shared@1.9.3(@algolia/client-search@5.17.1)(algoliasearch@5.12.0):
     resolution: {integrity: sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
     dependencies:
-      '@algolia/client-search': 5.12.0
+      '@algolia/client-search': 5.17.1
       algoliasearch: 5.12.0
     dev: false
 
@@ -392,6 +392,11 @@ packages:
 
   /@algolia/client-common@5.12.0:
     resolution: {integrity: sha512-od3WmO8qxyfNhKc+K3D17tvun3IMs/xMNmxCG9MiElAkYVbPPTRUYMkRneCpmJyQI0hNx2/EA4kZgzVfQjO86Q==}
+    engines: {node: '>= 14.0.0'}
+    dev: false
+
+  /@algolia/client-common@5.17.1:
+    resolution: {integrity: sha512-5rb5+yPIie6912riAypTSyzbE23a7UM1UpESvD8GEPI4CcWQvA9DBlkRNx9qbq/nJ5pvv8VjZjUxJj7rFkzEAA==}
     engines: {node: '>= 14.0.0'}
     dev: false
 
@@ -435,6 +440,16 @@ packages:
       '@algolia/requester-node-http': 5.12.0
     dev: false
 
+  /@algolia/client-search@5.17.1:
+    resolution: {integrity: sha512-bd5JBUOP71kPsxwDcvOxqtqXXVo/706NFifZ/O5Rx5GB8ZNVAhg4l7aGoT6jBvEfgmrp2fqPbkdIZ6JnuOpGcw==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@algolia/client-common': 5.17.1
+      '@algolia/requester-browser-xhr': 5.17.1
+      '@algolia/requester-fetch': 5.17.1
+      '@algolia/requester-node-http': 5.17.1
+    dev: false
+
   /@algolia/ingestion@1.12.0:
     resolution: {integrity: sha512-zpHo6qhR22tL8FsdSI4DvEraPDi/019HmMrCFB/TUX98yzh5ooAU7sNW0qPL1I7+S++VbBmNzJOEU9VI8tEC8A==}
     engines: {node: '>= 14.0.0'}
@@ -472,6 +487,13 @@ packages:
       '@algolia/client-common': 5.12.0
     dev: false
 
+  /@algolia/requester-browser-xhr@5.17.1:
+    resolution: {integrity: sha512-XpKgBfyczVesKgr7DOShNyPPu5kqlboimRRPjdqAw5grSyHhCmb8yoTIKy0TCqBABZeXRPMYT13SMruUVRXvHA==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@algolia/client-common': 5.17.1
+    dev: false
+
   /@algolia/requester-fetch@5.12.0:
     resolution: {integrity: sha512-FuDZXUGU1pAg2HCnrt8+q1VGHKChV/LhvjvZlLOT7e56GJie6p+EuLu4/hMKPOVuQQ8XXtrTHKIU3Lw+7O5/bQ==}
     engines: {node: '>= 14.0.0'}
@@ -479,11 +501,25 @@ packages:
       '@algolia/client-common': 5.12.0
     dev: false
 
+  /@algolia/requester-fetch@5.17.1:
+    resolution: {integrity: sha512-EhUomH+DZP5vb6DnEjT0GvXaXBSwzZnuU6hPGNU1EYKRXDouRjII/bIWpVjt7ycMgL2D2oQruqDh6rAWUhQwRw==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@algolia/client-common': 5.17.1
+    dev: false
+
   /@algolia/requester-node-http@5.12.0:
     resolution: {integrity: sha512-ncDDY7CxZhMs6LIoPl+vHFQceIBhYPY5EfuGF1V7beO0U38xfsCYEyutEFB2kRzf4D9Gqppn3iWX71sNtrKcuw==}
     engines: {node: '>= 14.0.0'}
     dependencies:
       '@algolia/client-common': 5.12.0
+    dev: false
+
+  /@algolia/requester-node-http@5.17.1:
+    resolution: {integrity: sha512-PSnENJtl4/wBWXlGyOODbLYm6lSiFqrtww7UpQRCJdsHXlJKF8XAP6AME8NxvbE0Qo/RJUxK0mvyEh9sQcx6bg==}
+    engines: {node: '>= 14.0.0'}
+    dependencies:
+      '@algolia/client-common': 5.17.1
     dev: false
 
   /@alloc/quick-lru@5.2.0:
@@ -687,7 +723,7 @@ packages:
     resolution: {integrity: sha512-3uvbg8E7rhqE1C4oBAK3tGlS2qfhi9zpfZgH/yjDPF73vd9B41urVIKujF4rczcF4E3qs34SedhehiDJ4UdNBA==}
     dev: false
 
-  /@docsearch/react@3.6.3(@algolia/client-search@5.12.0)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)(search-insights@2.17.2)(types-react@19.0.0-rc.1):
+  /@docsearch/react@3.6.3(@algolia/client-search@5.17.1)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)(search-insights@2.17.3)(types-react@19.0.0-rc.1):
     resolution: {integrity: sha512-2munr4uBuZq1PG+Ge+F+ldIdxb3Wi8OmEIv2tQQb4RvEvvph+xtQkxwHzVIEnt5s+HecwucuXwB+3JhcZboFLg==}
     peerDependencies:
       '@types/react': npm:types-react@rc
@@ -704,14 +740,14 @@ packages:
       search-insights:
         optional: true
     dependencies:
-      '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)(search-insights@2.17.2)
-      '@algolia/autocomplete-preset-algolia': 1.17.6(@algolia/client-search@5.12.0)(algoliasearch@5.12.0)
+      '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.6(@algolia/client-search@5.17.1)(algoliasearch@5.12.0)
       '@docsearch/css': 3.6.3
       '@types/react': /types-react@19.0.0-rc.1
       algoliasearch: 5.12.0
       react: 19.0.0-rc-603e6108-20241029
       react-dom: 19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029)
-      search-insights: 2.17.2
+      search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
     dev: false
@@ -797,8 +833,23 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@formatjs/ecma402-abstract@2.3.1:
+    resolution: {integrity: sha512-Ip9uV+/MpLXWRk03U/GzeJMuPeOXpJBSB5V1tjA6kJhvqssye5J5LoYLc7Z5IAHb7nR62sRoguzrFiVCP/hnzw==}
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.5
+      '@formatjs/intl-localematcher': 0.5.9
+      decimal.js: 10.4.3
+      tslib: 2.8.1
+    dev: false
+
   /@formatjs/fast-memoize@2.2.2:
     resolution: {integrity: sha512-mzxZcS0g1pOzwZTslJOBTmLzDXseMLLvnh25ymRilCm8QLMObsQ7x/rj9GNrH0iUhZMlFisVOD6J1n6WQqpKPQ==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@formatjs/fast-memoize@2.2.5:
+    resolution: {integrity: sha512-6PoewUMrrcqxSoBXAOJDiW1m+AmkrAj0RiXnOMD59GRaswjXhm3MDhgepXPBgonc09oSirAJTsAggzAGQf6A6g==}
     dependencies:
       tslib: 2.8.1
     dev: false
@@ -811,6 +862,21 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@formatjs/icu-messageformat-parser@2.9.7:
+    resolution: {integrity: sha512-cuEHyRM5VqLQobANOjtjlgU7+qmk9Q3fDQuBiRRJ3+Wp3ZoZhpUPtUfuimZXsir6SaI2TaAJ+SLo9vLnV5QcbA==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.1
+      '@formatjs/icu-skeleton-parser': 1.8.11
+      tslib: 2.8.1
+    dev: false
+
+  /@formatjs/icu-skeleton-parser@1.8.11:
+    resolution: {integrity: sha512-8LlHHE/yL/zVJZHAX3pbKaCjZKmBIO6aJY1mkVh4RMSEu/2WRZ4Ysvv3kKXJ9M8RJLBHdnk1/dUQFdod1Dt7Dw==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.1
+      tslib: 2.8.1
+    dev: false
+
   /@formatjs/icu-skeleton-parser@1.8.5:
     resolution: {integrity: sha512-zRZ/e3B5qY2+JCLs7puTzWS1Jb+t/K+8Jur/gEZpA2EjWeLDE17nsx8thyo9P48Mno7UmafnPupV2NCJXX17Dg==}
     dependencies:
@@ -820,6 +886,12 @@ packages:
 
   /@formatjs/intl-localematcher@0.5.6:
     resolution: {integrity: sha512-roz1+Ba5e23AHX6KUAWmLEyTRZegM5YDuxuvkHCyK3RJddf/UXB2f+s7pOMm9ktfPGla0g+mQXOn5vsuYirnaA==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
+  /@formatjs/intl-localematcher@0.5.9:
+    resolution: {integrity: sha512-8zkGu/sv5euxbjfZ/xmklqLyDGQSxsLqg8XOq88JW3cmJtzhCP8EtSJXlaKZnVO4beEaoiT9wj4eIoCQ9smwxA==}
     dependencies:
       tslib: 2.8.1
     dev: false
@@ -1040,11 +1112,24 @@ packages:
       '@swc/helpers': 0.5.13
     dev: false
 
+  /@internationalized/date@3.6.0:
+    resolution: {integrity: sha512-+z6ti+CcJnRlLHok/emGEsWQhe7kfSmEW+/6qCzvKY67YPh7YOBfvc7+/+NXq+zJlbArg30tYpqLjNgcAYv2YQ==}
+    dependencies:
+      '@swc/helpers': 0.5.15
+    dev: false
+
   /@internationalized/message@3.1.5:
     resolution: {integrity: sha512-hjEpLKFlYA3m5apldLqzHqw531qqfOEq0HlTWdfyZmcloWiUbWsYXD6YTiUmQmOtarthzhdjCAwMVrB8a4E7uA==}
     dependencies:
       '@swc/helpers': 0.5.13
       intl-messageformat: 10.7.3
+    dev: false
+
+  /@internationalized/message@3.1.6:
+    resolution: {integrity: sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==}
+    dependencies:
+      '@swc/helpers': 0.5.15
+      intl-messageformat: 10.7.10
     dev: false
 
   /@internationalized/number@3.5.4:
@@ -1053,10 +1138,22 @@ packages:
       '@swc/helpers': 0.5.13
     dev: false
 
+  /@internationalized/number@3.6.0:
+    resolution: {integrity: sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==}
+    dependencies:
+      '@swc/helpers': 0.5.15
+    dev: false
+
   /@internationalized/string@3.2.4:
     resolution: {integrity: sha512-BcyadXPn89Ae190QGZGDUZPqxLj/xsP4U1Br1oSy8yfIjmpJ8cJtGYleaodqW/EmzFjwELtwDojLkf3FhV6SjA==}
     dependencies:
       '@swc/helpers': 0.5.13
+    dev: false
+
+  /@internationalized/string@3.2.5:
+    resolution: {integrity: sha512-rKs71Zvl2OKOHM+mzAFMIyqR5hI1d1O6BBkMK2/lkfg3fkmVh9Eeg0awcA8W2WqYqDOv6a86DIOlFpggwLtbuw==}
+    dependencies:
+      '@swc/helpers': 0.5.15
     dev: false
 
   /@isaacs/cliui@8.0.2:
@@ -1239,7 +1336,7 @@ packages:
     dev: false
     optional: true
 
-  /@nextui-org/date-input@2.1.4(@nextui-org/system@2.2.6)(@nextui-org/theme@2.2.11)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
+  /@nextui-org/date-input@2.1.4(@nextui-org/system@2.4.4)(@nextui-org/theme@2.4.3)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-U8Pbe7EhMp9VTfFxB/32+A9N9cJJWswebIz1qpaPy0Hmr92AHS3c1qVTcspkop6wbIM8AnHWEST0QkR95IXPDA==}
     peerDependencies:
       '@nextui-org/system': '>=2.1.0'
@@ -1250,8 +1347,8 @@ packages:
       '@internationalized/date': 3.5.6
       '@nextui-org/react-utils': 2.0.17(react@19.0.0-rc-603e6108-20241029)
       '@nextui-org/shared-utils': 2.0.8
-      '@nextui-org/system': 2.2.6(@nextui-org/theme@2.2.11)(framer-motion@11.11.11)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
-      '@nextui-org/theme': 2.2.11(tailwindcss@3.4.14)
+      '@nextui-org/system': 2.4.4(@nextui-org/theme@2.4.3)(framer-motion@11.15.0)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
+      '@nextui-org/theme': 2.4.3(tailwindcss@3.4.14)
       '@react-aria/datepicker': 3.10.1(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
       '@react-aria/i18n': 3.11.1(react@19.0.0-rc-603e6108-20241029)
       '@react-aria/utils': 3.24.1(react@19.0.0-rc-603e6108-20241029)
@@ -1270,6 +1367,14 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@nextui-org/react-rsc-utils@2.1.1(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-9uKH1XkeomTGaswqlGKt0V0ooUev8mPXtKJolR+6MnpvBUrkqngw1gUGF0bq/EcCCkks2+VOHXZqFT6x9hGkQQ==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+    dependencies:
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@nextui-org/react-utils@2.0.17(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-U/b49hToVfhOM4dg4n57ZyUjLpts4JogQ139lfQBYPTb8z/ATNsJ3vLIqW5ZvDK6L0Er+JT11UVQ+03m7QMvaQ==}
     peerDependencies:
@@ -1280,59 +1385,70 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@nextui-org/react-utils@2.1.1(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-cN3Z0b2bV6Nf0CYD4imsGdXbHMQqad8KivltpBv1ItbI1/FSTAv9AHTKSzDE15hd/UwOGYt3Qm7I6tWzqov55w==}
+    peerDependencies:
+      react: '>=18 || >=19.0.0-rc.0'
+    dependencies:
+      '@nextui-org/react-rsc-utils': 2.1.1(react@19.0.0-rc-603e6108-20241029)
+      '@nextui-org/shared-utils': 2.1.1
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@nextui-org/shared-utils@2.0.8:
     resolution: {integrity: sha512-ZEtoMPXS+IjT8GvpJTS9IWDnT1JNCKV+NDqqgysAf1niJmOFLyJgl6dh/9n4ufcGf1GbSEQN+VhJasEw7ajYGQ==}
     dev: false
 
-  /@nextui-org/system-rsc@2.1.6(@nextui-org/theme@2.2.11)(react@19.0.0-rc-603e6108-20241029):
-    resolution: {integrity: sha512-Wl2QwEFjYwuvw26R1RH3ZY81PD8YmfgtIjFvJZRP2VEIT6rPvlQ4ojgqdrkVkQZQ0L/K+5ZLbTKgLEFkj5ysdQ==}
+  /@nextui-org/shared-utils@2.1.1:
+    resolution: {integrity: sha512-qE8gZO63GqUX1ljOi/4PlwGzE84dhUS3zFIq+10/N6ePAaNjM4DwtL4ocucG3abCz4iRUueYKLIxTO2+eYyAfw==}
+    dev: false
+
+  /@nextui-org/system-rsc@2.3.4(@nextui-org/theme@2.4.3)(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-Y6OLFO7diYnUMe5ffDPt6sIqCaah7FOqRaJ3ZQ/We8gE8AgHnyNQxWllLtRzBqaCiIheHLo7dTMed1FFmb775A==}
     peerDependencies:
-      '@nextui-org/theme': '>=2.1.0'
-      react: '>=18'
+      '@nextui-org/theme': '>=2.4.0'
+      react: '>=18 || >=19.0.0-rc.0'
     dependencies:
-      '@nextui-org/theme': 2.2.11(tailwindcss@3.4.14)
-      '@react-types/shared': 3.23.1(react@19.0.0-rc-603e6108-20241029)
+      '@nextui-org/theme': 2.4.3(tailwindcss@3.4.14)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
       clsx: 1.2.1
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
-  /@nextui-org/system@2.2.6(@nextui-org/theme@2.2.11)(framer-motion@11.11.11)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
-    resolution: {integrity: sha512-tjIkOI0w32g68CGWleuSyIbEz8XBbeoNogR2lu7MWk3QovHCqgr4VVrP1cwMRYnwDPFQP3OpmH+NR9yzt+pIfg==}
+  /@nextui-org/system@2.4.4(@nextui-org/theme@2.4.3)(framer-motion@11.15.0)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-ldlUYq7VprTEC2s3LaMxQh7S7Xeyy6DYoKkOML9XHJBgSgVXCMr5QyoxvIkO2XRl5nu6KWn2QA1vjtj2xiMjRw==}
     peerDependencies:
-      framer-motion: '>=10.17.0'
-      react: '>=18'
-      react-dom: '>=18'
+      framer-motion: '>=11.5.6 || >=12.0.0-alpha.1'
+      react: '>=18 || >=19.0.0-rc.0'
+      react-dom: '>=18 || >=19.0.0-rc.0'
     dependencies:
-      '@internationalized/date': 3.5.6
-      '@nextui-org/react-utils': 2.0.17(react@19.0.0-rc-603e6108-20241029)
-      '@nextui-org/system-rsc': 2.1.6(@nextui-org/theme@2.2.11)(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/i18n': 3.11.1(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/overlays': 3.22.1(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/utils': 3.24.1(react@19.0.0-rc-603e6108-20241029)
-      '@react-stately/utils': 3.10.1(react@19.0.0-rc-603e6108-20241029)
-      framer-motion: 11.11.11(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
+      '@internationalized/date': 3.6.0
+      '@nextui-org/react-utils': 2.1.1(react@19.0.0-rc-603e6108-20241029)
+      '@nextui-org/system-rsc': 2.3.4(@nextui-org/theme@2.4.3)(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/i18n': 3.12.4(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/overlays': 3.24.0(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-stately/utils': 3.10.5(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/datepicker': 3.9.0(react@19.0.0-rc-603e6108-20241029)
+      framer-motion: 11.15.0(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
       react: 19.0.0-rc-603e6108-20241029
       react-dom: 19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029)
     transitivePeerDependencies:
       - '@nextui-org/theme'
     dev: false
 
-  /@nextui-org/theme@2.2.11(tailwindcss@3.4.14):
-    resolution: {integrity: sha512-bg9+KNnFxcP3w/ugivEJtvQibODbTxfl6UdVvx7TCY8Rd269U7F2+nhnw1Qd1xJT5yZQnX6m//9wOoGtJV+6Kg==}
+  /@nextui-org/theme@2.4.3(tailwindcss@3.4.14):
+    resolution: {integrity: sha512-QH9ps5NpenWU966INdGbdvZOWWUEGqxrLM2vyqkSRq+A65YON4Jhg/x1xWcSX0SJECNhoNZLh5mt6jp3jH5k8Q==}
     peerDependencies:
       tailwindcss: '>=3.4.0'
     dependencies:
+      '@nextui-org/shared-utils': 2.1.1
       clsx: 1.2.1
       color: 4.2.3
       color2k: 2.0.3
       deepmerge: 4.3.1
       flat: 5.0.2
-      lodash.foreach: 4.5.0
-      lodash.get: 4.4.2
-      lodash.kebabcase: 4.1.1
-      lodash.mapkeys: 4.6.0
-      lodash.omit: 4.5.0
-      tailwind-merge: 1.14.0
+      tailwind-merge: 2.5.5
       tailwind-variants: 0.1.20(tailwindcss@3.4.14)
       tailwindcss: 3.4.14
     dev: false
@@ -2339,6 +2455,19 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@react-aria/focus@3.19.0(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-hPF9EXoUQeQl1Y21/rbV2H4FdUR2v+4/I0/vB+8U3bT1CJ+1AFj1hc/rqx2DqEwDlEwOHN+E4+mRahQmlybq0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/interactions': 3.22.5(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@swc/helpers': 0.5.15
+      clsx: 2.1.1
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@react-aria/form@3.0.10(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-hWBrqEXxBxcpYTJv0telQKaiu2728EUFHta8/RGBqJ4+MhKKxI7+PnLoms78IuiK0MCYvukHfun1fuQvK+8jsg==}
     peerDependencies:
@@ -2384,6 +2513,22 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@react-aria/i18n@3.12.4(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-j9+UL3q0Ls8MhXV9gtnKlyozq4aM95YywXqnmJtzT1rYeBx7w28hooqrWkCYLfqr4OIryv1KUnPiCSLwC2OC7w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@internationalized/date': 3.6.0
+      '@internationalized/message': 3.1.6
+      '@internationalized/number': 3.6.0
+      '@internationalized/string': 3.2.5
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@swc/helpers': 0.5.15
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@react-aria/interactions@3.22.4(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-E0vsgtpItmknq/MJELqYJwib+YN18Qag8nroqwjk1qOnBa9ROIkUhWJerLi1qs5diXq9LHKehZDXRlwPvdEFww==}
     peerDependencies:
@@ -2393,6 +2538,18 @@ packages:
       '@react-aria/utils': 3.25.3(react@19.0.0-rc-603e6108-20241029)
       '@react-types/shared': 3.25.0(react@19.0.0-rc-603e6108-20241029)
       '@swc/helpers': 0.5.13
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
+  /@react-aria/interactions@3.22.5(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-kMwiAD9E0TQp+XNnOs13yVJghiy8ET8L0cbkeuTgNI96sOAp/63EJ1FSrDf17iD8sdjt41LafwX/dKXW9nCcLQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@swc/helpers': 0.5.15
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
@@ -2413,23 +2570,23 @@ packages:
       '@swc/helpers': 0.5.13
     dev: false
 
-  /@react-aria/overlays@3.22.1(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
-    resolution: {integrity: sha512-GHiFMWO4EQ6+j6b5QCnNoOYiyx1Gk8ZiwLzzglCI4q1NY5AG2EAmfU4Z1+Gtrf2S5Y0zHbumC7rs9GnPoGLUYg==}
+  /@react-aria/overlays@3.24.0(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-0kAXBsMNTc/a3M07tK9Cdt/ea8CxTAEJ223g8YgqImlmoBBYAL7dl5G01IOj67TM64uWPTmZrOklBchHWgEm3A==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     dependencies:
-      '@react-aria/focus': 3.18.4(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/i18n': 3.12.3(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/interactions': 3.22.4(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/ssr': 3.9.6(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/utils': 3.25.3(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/visually-hidden': 3.8.17(react@19.0.0-rc-603e6108-20241029)
-      '@react-stately/overlays': 3.6.11(react@19.0.0-rc-603e6108-20241029)
-      '@react-types/button': 3.10.0(react@19.0.0-rc-603e6108-20241029)
-      '@react-types/overlays': 3.8.10(react@19.0.0-rc-603e6108-20241029)
-      '@react-types/shared': 3.25.0(react@19.0.0-rc-603e6108-20241029)
-      '@swc/helpers': 0.5.13
+      '@react-aria/focus': 3.19.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/i18n': 3.12.4(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/interactions': 3.22.5(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/visually-hidden': 3.8.18(react@19.0.0-rc-603e6108-20241029)
+      '@react-stately/overlays': 3.6.12(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/button': 3.10.1(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/overlays': 3.8.11(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@swc/helpers': 0.5.15
       react: 19.0.0-rc-603e6108-20241029
       react-dom: 19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029)
     dev: false
@@ -2460,6 +2617,16 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@react-aria/ssr@3.9.7(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.15
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@react-aria/utils@3.24.1(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==}
     peerDependencies:
@@ -2486,15 +2653,28 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
-  /@react-aria/visually-hidden@3.8.17(react@19.0.0-rc-603e6108-20241029):
-    resolution: {integrity: sha512-WFgny1q2CbxxU6gu46TGQXf1DjsnuSk+RBDP4M7bm1mUVZzoCp7U7AtjNmsBrWg0NejxUdgD7+7jkHHCQ91qRA==}
+  /@react-aria/utils@3.26.0(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-LkZouGSjjQ0rEqo4XJosS4L3YC/zzQkfRM3KoqK6fUOmUJ9t0jQ09WjiF+uOoG9u+p30AVg3TrZRUWmoTS+koQ==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     dependencies:
-      '@react-aria/interactions': 3.22.4(react@19.0.0-rc-603e6108-20241029)
-      '@react-aria/utils': 3.25.3(react@19.0.0-rc-603e6108-20241029)
-      '@react-types/shared': 3.25.0(react@19.0.0-rc-603e6108-20241029)
-      '@swc/helpers': 0.5.13
+      '@react-aria/ssr': 3.9.7(react@19.0.0-rc-603e6108-20241029)
+      '@react-stately/utils': 3.10.5(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@swc/helpers': 0.5.15
+      clsx: 2.1.1
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
+  /@react-aria/visually-hidden@3.8.18(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-l/0igp+uub/salP35SsNWq5mGmg3G5F5QMS1gDZ8p28n7CgjvzyiGhJbbca7Oxvaw1HRFzVl9ev+89I7moNnFQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-aria/interactions': 3.22.5(react@19.0.0-rc-603e6108-20241029)
+      '@react-aria/utils': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      '@swc/helpers': 0.5.15
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
@@ -2765,12 +2945,14 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
-  /@react-stately/utils@3.10.1(react@19.0.0-rc-603e6108-20241029):
-    resolution: {integrity: sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==}
+  /@react-stately/overlays@3.6.12(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-QinvZhwZgj8obUyPIcyURSCjTZlqZYRRCS60TF8jH8ZpT0tEAuDb3wvhhSXuYA3Xo9EHLwvLjEf3tQKKdAQArw==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     dependencies:
-      '@swc/helpers': 0.5.13
+      '@react-stately/utils': 3.10.5(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/overlays': 3.8.11(react@19.0.0-rc-603e6108-20241029)
+      '@swc/helpers': 0.5.15
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
@@ -2783,12 +2965,30 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@react-stately/utils@3.10.5(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@swc/helpers': 0.5.15
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@react-types/button@3.10.0(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-rAyU+N9VaHLBdZop4zasn8IDwf9I5Q1EzHUKMtzIFf5aUlMUW+K460zI/l8UESWRSWAXK9/WPSXGxfcoCEjvAA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
     dependencies:
       '@react-types/shared': 3.25.0(react@19.0.0-rc-603e6108-20241029)
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
+  /@react-types/button@3.10.1(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-XTtap8o04+4QjPNAshFWOOAusUTxQlBjU2ai0BTVLShQEjHhRVDBIWsI2B2FKJ4KXT6AZ25llaxhNrreWGonmA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
@@ -2802,6 +3002,16 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@react-types/calendar@3.5.0(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-O3IRE7AGwAWYnvJIJ80cOy7WwoJ0m8GtX/qSmvXQAjC4qx00n+b5aFNBYAQtcyc3RM5QpW6obs9BfwGetFiI8w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@internationalized/date': 3.6.0
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@react-types/datepicker@3.7.4(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-ZfvgscvNzBJpYyVWg3nstJtA/VlWLwErwSkd1ivZYam859N30w8yH+4qoYLa6FzWLCFlrsRHyvtxlEM7lUAt5A==}
     peerDependencies:
@@ -2811,6 +3021,18 @@ packages:
       '@react-types/calendar': 3.4.10(react@19.0.0-rc-603e6108-20241029)
       '@react-types/overlays': 3.8.10(react@19.0.0-rc-603e6108-20241029)
       '@react-types/shared': 3.23.1(react@19.0.0-rc-603e6108-20241029)
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
+  /@react-types/datepicker@3.9.0(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-dbKL5Qsm2MQwOTtVQdOcKrrphcXAqDD80WLlSQrBLg+waDuuQ7H+TrvOT0thLKloNBlFUGnZZfXGRHINpih/0g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@internationalized/date': 3.6.0
+      '@react-types/calendar': 3.5.0(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/overlays': 3.8.11(react@19.0.0-rc-603e6108-20241029)
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
@@ -2833,6 +3055,15 @@ packages:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
 
+  /@react-types/overlays@3.8.11(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-aw7T0rwVI3EuyG5AOaEIk8j7dZJQ9m34XAztXJVZ/W2+4pDDkLDbJ/EAPnuo2xGYRGhowuNDn4tDju01eHYi+w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    dependencies:
+      '@react-types/shared': 3.26.0(react@19.0.0-rc-603e6108-20241029)
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
   /@react-types/shared@3.23.1(react@19.0.0-rc-603e6108-20241029):
     resolution: {integrity: sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==}
     peerDependencies:
@@ -2845,6 +3076,14 @@ packages:
     resolution: {integrity: sha512-OZSyhzU6vTdW3eV/mz5i6hQwQUhkRs7xwY2d1aqPvTdMe0+2cY7Fwp45PAiwYLEj73i9ro2FxF9qC4DvHGSCgQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    dependencies:
+      react: 19.0.0-rc-603e6108-20241029
+    dev: false
+
+  /@react-types/shared@3.26.0(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     dependencies:
       react: 19.0.0-rc-603e6108-20241029
     dev: false
@@ -3099,6 +3338,12 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@swc/helpers@0.5.15:
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
   /@t3-oss/env-core@0.10.1(typescript@5.6.3)(zod@3.23.8):
     resolution: {integrity: sha512-GcKZiCfWks5CTxhezn9k5zWX3sMDIYf6Kaxy2Gx9YEQftFcz8hDRN56hcbylyAO3t4jQnQ5ifLawINsNgCDpOg==}
     peerDependencies:
@@ -3252,7 +3497,7 @@ packages:
     resolution: {integrity: sha512-IzSzb6doT4I4uAnBHa+mBCiNtK7iAllEJjtpkX0sKY6/s1Vi+aX1134IAiPgiyFlMvFab/oZQpSeccK4r0/T2A==}
     dev: true
 
-  /@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.12.2)(eslint@8.57.1)(typescript@5.6.3):
+  /@typescript-eslint/eslint-plugin@8.12.2(@typescript-eslint/parser@8.18.1)(eslint@8.57.1)(typescript@5.6.3):
     resolution: {integrity: sha512-gQxbxM8mcxBwaEmWdtLCIGLfixBMHhQjBqR8sVWNTPpcj45WlYL2IObS/DNMLH1DBP0n8qz+aiiLTGfopPEebw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
@@ -3264,7 +3509,7 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.12.2(eslint@8.57.1)(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.18.1(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/scope-manager': 8.12.2
       '@typescript-eslint/type-utils': 8.12.2(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/utils': 8.12.2(eslint@8.57.1)(typescript@5.6.3)
@@ -3300,21 +3545,18 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@8.12.2(eslint@8.57.1)(typescript@5.6.3):
-    resolution: {integrity: sha512-MrvlXNfGPLH3Z+r7Tk+Z5moZAc0dzdVjTgUgwsdGweH7lydysQsnSww3nAmsq8blFuRD5VRlAr9YdEFw3e6PBw==}
+  /@typescript-eslint/parser@8.18.1(eslint@8.57.1)(typescript@5.6.3):
+    resolution: {integrity: sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/scope-manager': 8.12.2
-      '@typescript-eslint/types': 8.12.2
-      '@typescript-eslint/typescript-estree': 8.12.2(typescript@5.6.3)
-      '@typescript-eslint/visitor-keys': 8.12.2
-      debug: 4.3.7
+      '@typescript-eslint/scope-manager': 8.18.1
+      '@typescript-eslint/types': 8.18.1
+      '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.6.3)
+      '@typescript-eslint/visitor-keys': 8.18.1
+      debug: 4.4.0
       eslint: 8.57.1
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -3335,6 +3577,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.12.2
       '@typescript-eslint/visitor-keys': 8.12.2
+    dev: true
+
+  /@typescript-eslint/scope-manager@8.18.1:
+    resolution: {integrity: sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.18.1
+      '@typescript-eslint/visitor-keys': 8.18.1
     dev: true
 
   /@typescript-eslint/type-utils@8.12.2(eslint@8.57.1)(typescript@5.6.3):
@@ -3363,6 +3613,11 @@ packages:
 
   /@typescript-eslint/types@8.12.2:
     resolution: {integrity: sha512-VwDwMF1SZ7wPBUZwmMdnDJ6sIFk4K4s+ALKLP6aIQsISkPv8jhiw65sAK6SuWODN/ix+m+HgbYDkH+zLjrzvOA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dev: true
+
+  /@typescript-eslint/types@8.18.1:
+    resolution: {integrity: sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
@@ -3410,6 +3665,25 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/typescript-estree@8.18.1(typescript@5.6.3):
+    resolution: {integrity: sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+    dependencies:
+      '@typescript-eslint/types': 8.18.1
+      '@typescript-eslint/visitor-keys': 8.18.1
+      debug: 4.4.0
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.4.3(typescript@5.6.3)
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/utils@8.12.2(eslint@8.57.1)(typescript@5.6.3):
     resolution: {integrity: sha512-UTTuDIX3fkfAz6iSVa5rTuSfWIYZ6ATtEocQ/umkRSyC9O919lbZ8dcH7mysshrCdrAM03skJOEYaBugxN+M6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3440,6 +3714,14 @@ packages:
     dependencies:
       '@typescript-eslint/types': 8.12.2
       eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@typescript-eslint/visitor-keys@8.18.1:
+    resolution: {integrity: sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dependencies:
+      '@typescript-eslint/types': 8.18.1
+      eslint-visitor-keys: 4.2.0
     dev: true
 
   /@typescript/vfs@1.6.0(typescript@5.6.3):
@@ -4067,6 +4349,22 @@ packages:
     dependencies:
       ms: 2.1.3
 
+  /debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
+  /decimal.js@10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
+    dev: false
+
   /decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
     dependencies:
@@ -4612,6 +4910,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
+  /eslint-visitor-keys@4.2.0:
+    resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    dev: true
+
   /eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -4869,12 +5172,12 @@ packages:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true
 
-  /framer-motion@11.11.11(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
-    resolution: {integrity: sha512-tuDH23ptJAKUHGydJQII9PhABNJBpB+z0P1bmgKK9QFIssHGlfPd6kxMq00LSKwE27WFsb2z0ovY0bpUyMvfRw==}
+  /framer-motion@11.15.0(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-MLk8IvZntxOMg7lDBLw2qgTHHv664bYoYmnFTmE0Gm/FW67aOJk0WM3ctMcG+Xhcv+vh5uyyXwxvxhSeJzSe+w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0
-      react-dom: ^18.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -4883,6 +5186,8 @@ packages:
       react-dom:
         optional: true
     dependencies:
+      motion-dom: 11.14.3
+      motion-utils: 11.14.3
       react: 19.0.0-rc-603e6108-20241029
       react-dom: 19.0.0-rc-603e6108-20241029(react@19.0.0-rc-603e6108-20241029)
       tslib: 2.8.1
@@ -5270,6 +5575,15 @@ packages:
       hasown: 2.0.2
       side-channel: 1.0.6
     dev: true
+
+  /intl-messageformat@10.7.10:
+    resolution: {integrity: sha512-hp7iejCBiJdW3zmOe18FdlJu8U/JsADSDiBPQhfdSeI8B9POtvPRvPh3nMlvhYayGMKLv6maldhR7y3Pf1vkpw==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.1
+      '@formatjs/fast-memoize': 2.2.5
+      '@formatjs/icu-messageformat-parser': 2.9.7
+      tslib: 2.8.1
+    dev: false
 
   /intl-messageformat@10.7.3:
     resolution: {integrity: sha512-AAo/3oyh7ROfPhDuh7DxTTydh97OC+lv7h1Eq5LuHWuLsUMKOhtzTYuyXlUReuwZ9vANDHo4CS1bGRrn7TZRtg==}
@@ -5677,33 +5991,13 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: false
 
-  /lodash.foreach@4.5.0:
-    resolution: {integrity: sha512-aEXTF4d+m05rVOAUG3z4vZZ4xVexLKZGF0lIxuHZ1Hplpk/3B6Z1+/ICICYRLm7c41Z2xiejbkCkJoTlypoXhQ==}
-    dev: false
-
-  /lodash.get@4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    dev: false
-
   /lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
     dev: true
 
-  /lodash.kebabcase@4.1.1:
-    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
-    dev: false
-
-  /lodash.mapkeys@4.6.0:
-    resolution: {integrity: sha512-0Al+hxpYvONWtg+ZqHpa/GaVzxuN3V7Xeo2p+bY06EaK/n+Y9R7nBePPN2o1LxmL0TWQSwP8LYZ008/hc9JzhA==}
-    dev: false
-
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
-
-  /lodash.omit@4.5.0:
-    resolution: {integrity: sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==}
-    dev: false
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -6375,6 +6669,14 @@ packages:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
     dev: false
 
+  /motion-dom@11.14.3:
+    resolution: {integrity: sha512-lW+D2wBy5vxLJi6aCP0xyxTxlTfiu+b+zcpVbGVFUxotwThqhdpPRSmX8xztAgtZMPMeU0WGVn/k1w4I+TbPqA==}
+    dev: false
+
+  /motion-utils@11.14.3:
+    resolution: {integrity: sha512-Xg+8xnqIJTpr0L/cidfTTBFkvRw26ZtGGuIhA94J9PQ2p4mEa06Xx7QVYZH0BP+EpMSaDlu+q0I0mmvwADPsaQ==}
+    dev: false
+
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -6535,13 +6837,24 @@ packages:
       boolbase: 1.0.0
     dev: true
 
-  /nuqs@1.20.0(next@15.0.2):
-    resolution: {integrity: sha512-nGVfv7eWMNxAzOJ9n8ARTo6ObqeEr1ETYZ+dIMCg/VfGUoZoPrqyTOndIvQIgUzK3pIC41mTXg10JJxh9ziEhw==}
+  /nuqs@2.2.3(next@15.0.2)(react@19.0.0-rc-603e6108-20241029):
+    resolution: {integrity: sha512-nMCcUW06KSqEXA0xp+LiRqDpIE59BVYbjZLe0HUisJAlswfihHYSsAjYTzV0lcE1thfh8uh+LqUHGdQ8qq8rfA==}
     peerDependencies:
-      next: '>=13.4 <14.0.2 || ^14.0.3'
+      '@remix-run/react': '>=2'
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router-dom: '>=6'
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      next:
+        optional: true
+      react-router-dom:
+        optional: true
     dependencies:
       mitt: 3.0.1
       next: 15.0.2(@babel/core@7.26.0)(react-dom@19.0.0-rc-603e6108-20241029)(react@19.0.0-rc-603e6108-20241029)
+      react: 19.0.0-rc-603e6108-20241029
     dev: false
 
   /object-assign@4.1.1:
@@ -7346,8 +7659,8 @@ packages:
     resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
     dev: false
 
-  /search-insights@2.17.2:
-    resolution: {integrity: sha512-zFNpOpUO+tY2D85KrxJ+aqwnIfdEGi06UH2+xEb+Bp9Mwznmauqc9djbnBibJO5mpfUPPa8st6Sx65+vbeO45g==}
+  /search-insights@2.17.3:
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
     dev: false
 
   /section-matter@1.0.0:
@@ -7708,6 +8021,10 @@ packages:
     resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
     dev: false
 
+  /tailwind-merge@2.5.5:
+    resolution: {integrity: sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==}
+    dev: false
+
   /tailwind-variants@0.1.20(tailwindcss@3.4.14):
     resolution: {integrity: sha512-AMh7x313t/V+eTySKB0Dal08RHY7ggYK0MSn/ad8wKWOrDUIzyiWNayRUm2PIJ4VRkvRnfNuyRuKbLV3EN+ewQ==}
     engines: {node: '>=16.x', pnpm: '>=7.x'}
@@ -7798,6 +8115,15 @@ packages:
 
   /ts-api-utils@1.4.0(typescript@5.6.3):
     resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.6.3
+    dev: true
+
+  /ts-api-utils@1.4.3(typescript@5.6.3):
+    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'


### PR DESCRIPTION
## What

Updates `nuqs`, the library we use for URL search params, to the latest version

## Testing

### Before
![CleanShot 2024-12-16 at 23 52 53@2x](https://github.com/user-attachments/assets/e2637c9d-14bb-4dfb-ae82-cf19eb9cdae7)

### After
![CleanShot 2024-12-16 at 23 53 17@2x](https://github.com/user-attachments/assets/7dae1e12-2fde-4281-8844-8cef16868fdd)
