### PR TITLE
feat: disable deep linking for non multi select inputs

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -133,99 +133,113 @@ export function ProductDetail<F extends Field>({
   );
 }
 
-const ImageSkeleton = () => (
-  <div className="aspect-[4/5] h-full w-full shrink-0 grow-0 basis-full animate-pulse bg-contrast-100" />
-);
+function ImageSkeleton() {
+  return (
+    <div className="aspect-[4/5] h-full w-full shrink-0 grow-0 basis-full animate-pulse bg-contrast-100" />
+  );
+}
 
-const ThumbnailsSkeleton = () => (
-  <>
-    <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
-    <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
-    <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
-    <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
-  </>
-);
+function ThumbnailsSkeleton() {
+  return (
+    <>
+      <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
+      <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
+      <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
+      <div className="h-12 w-12 shrink-0 animate-pulse rounded-lg bg-contrast-100 @md:h-16 @md:w-16" />
+    </>
+  );
+}
 
-const ProductGallerySkeleton = () => (
-  <div className={'@container'}>
-    <div className="w-full overflow-hidden rounded-xl @xl:rounded-2xl">
-      <div className="flex">
-        <ImageSkeleton />
+function ProductGallerySkeleton() {
+  return (
+    <div className={'@container'}>
+      <div className="w-full overflow-hidden rounded-xl @xl:rounded-2xl">
+        <div className="flex">
+          <ImageSkeleton />
+        </div>
+      </div>
+
+      <div className="mt-2 flex max-w-full gap-2 overflow-x-auto">
+        <ThumbnailsSkeleton />
       </div>
     </div>
+  );
+}
 
-    <div className="mt-2 flex max-w-full gap-2 overflow-x-auto">
-      <ThumbnailsSkeleton />
+function PriceLabelSkeleton() {
+  return <div className="my-4 h-4 w-20 animate-pulse rounded-md bg-contrast-100" />;
+}
+
+function RatingSkeleton() {
+  return (
+    <div className="flex w-[136px] animate-pulse items-center gap-1">
+      <div className="h-4 w-[100px] rounded-md bg-contrast-100" />
+      <div className="h-6 w-8 rounded-xl bg-contrast-100" />
     </div>
-  </div>
-);
+  );
+}
 
-const PriceLabelSkeleton = () => (
-  <div className="my-4 h-4 w-20 animate-pulse rounded-md bg-contrast-100" />
-);
+function ProductDescriptionSkeleton() {
+  return (
+    <div className="flex w-full animate-pulse flex-col gap-3.5 pb-6">
+      <div className="h-2.5 w-full bg-contrast-100" />
+      <div className="h-2.5 w-full bg-contrast-100" />
+      <div className="h-2.5 w-3/4 bg-contrast-100" />
+    </div>
+  );
+}
 
-const RatingSkeleton = () => (
-  <div className="flex w-[136px] animate-pulse items-center gap-1">
-    <div className="h-4 w-[100px] rounded-md bg-contrast-100" />
-    <div className="h-6 w-8 rounded-xl bg-contrast-100" />
-  </div>
-);
-
-const ProductDescriptionSkeleton = () => (
-  <div className="flex w-full animate-pulse flex-col gap-3.5 pb-6">
-    <div className="h-2.5 w-full bg-contrast-100" />
-    <div className="h-2.5 w-full bg-contrast-100" />
-    <div className="h-2.5 w-3/4 bg-contrast-100" />
-  </div>
-);
-
-const ProductDetailFormSkeleton = () => (
-  <div className="flex animate-pulse flex-col gap-8">
-    <div className="flex flex-col gap-5">
-      <div className="h-2 w-10 rounded-md bg-contrast-100" />
+function ProductDetailFormSkeleton() {
+  return (
+    <div className="flex animate-pulse flex-col gap-8">
+      <div className="flex flex-col gap-5">
+        <div className="h-2 w-10 rounded-md bg-contrast-100" />
+        <div className="flex gap-2">
+          <div className="h-11 w-[72px] rounded-full bg-contrast-100" />
+          <div className="h-11 w-[72px] rounded-full bg-contrast-100" />
+          <div className="h-11 w-[72px] rounded-full bg-contrast-100" />
+        </div>
+      </div>
+      <div className="flex flex-col gap-5">
+        <div className="h-2 w-16 rounded-md bg-contrast-100" />
+        <div className="flex gap-4">
+          <div className="h-10 w-10 rounded-full bg-contrast-100" />
+          <div className="h-10 w-10 rounded-full bg-contrast-100" />
+          <div className="h-10 w-10 rounded-full bg-contrast-100" />
+          <div className="h-10 w-10 rounded-full bg-contrast-100" />
+          <div className="h-10 w-10 rounded-full bg-contrast-100" />
+        </div>
+      </div>
       <div className="flex gap-2">
-        <div className="h-11 w-[72px] rounded-full bg-contrast-100" />
-        <div className="h-11 w-[72px] rounded-full bg-contrast-100" />
-        <div className="h-11 w-[72px] rounded-full bg-contrast-100" />
+        <div className="h-12 w-[120px] rounded-lg bg-contrast-100" />
+        <div className="h-12 w-[216px] rounded-full bg-contrast-100" />
       </div>
     </div>
-    <div className="flex flex-col gap-5">
-      <div className="h-2 w-16 rounded-md bg-contrast-100" />
-      <div className="flex gap-4">
-        <div className="h-10 w-10 rounded-full bg-contrast-100" />
-        <div className="h-10 w-10 rounded-full bg-contrast-100" />
-        <div className="h-10 w-10 rounded-full bg-contrast-100" />
-        <div className="h-10 w-10 rounded-full bg-contrast-100" />
-        <div className="h-10 w-10 rounded-full bg-contrast-100" />
-      </div>
-    </div>
-    <div className="flex gap-2">
-      <div className="h-12 w-[120px] rounded-lg bg-contrast-100" />
-      <div className="h-12 w-[216px] rounded-full bg-contrast-100" />
-    </div>
-  </div>
-);
+  );
+}
 
-const ProductDetailSkeleton = () => (
-  <div className="grid animate-pulse grid-cols-1 items-stretch gap-x-6 gap-y-8 @2xl:grid-cols-2 @5xl:gap-x-12">
-    <div className="hidden @2xl:block">
-      <ProductGallerySkeleton />
-    </div>
-
-    <div>
-      <div className="mb-6 h-4 w-20 rounded-lg bg-contrast-100" />
-
-      <div className="mb-6 h-6 w-72 rounded-lg bg-contrast-100" />
-
-      <RatingSkeleton />
-
-      <PriceLabelSkeleton />
-
-      <div className="mb-8 @2xl:hidden">
+function ProductDetailSkeleton() {
+  return (
+    <div className="grid animate-pulse grid-cols-1 items-stretch gap-x-6 gap-y-8 @2xl:grid-cols-2 @5xl:gap-x-12">
+      <div className="hidden @2xl:block">
         <ProductGallerySkeleton />
       </div>
 
-      <ProductDetailFormSkeleton />
+      <div>
+        <div className="mb-6 h-4 w-20 rounded-lg bg-contrast-100" />
+
+        <div className="mb-6 h-6 w-72 rounded-lg bg-contrast-100" />
+
+        <RatingSkeleton />
+
+        <PriceLabelSkeleton />
+
+        <div className="mb-8 @2xl:hidden">
+          <ProductGallerySkeleton />
+        </div>
+
+        <ProductDetailFormSkeleton />
+      </div>
     </div>
-  </div>
-);
+  );
+}

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -11,7 +11,7 @@ import {
 } from '@conform-to/react';
 import { getZodConstraint, parseWithZod } from '@conform-to/zod';
 import { usePathname, useRouter } from 'next/navigation';
-import { createSerializer, parseAsString, useQueryState, useQueryStates } from 'nuqs';
+import { createSerializer, parseAsString, useQueryStates } from 'nuqs';
 import { ReactNode, useActionState, useCallback, useEffect } from 'react';
 import { useFormStatus } from 'react-dom';
 import { z } from 'zod';
@@ -30,7 +30,7 @@ import { toast } from '@/vibes/soul/primitives/toaster';
 
 import { Field, schema, SchemaRawShape } from './schema';
 
-type Action<State, Payload> = (state: Awaited<State>, payload: Payload) => State | Promise<State>;
+type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
 
 interface State<F extends Field> {
   fields: F[];
@@ -188,17 +188,16 @@ function FormField({
 }) {
   const controls = useInputControl(formField);
 
-  const [, setParam] = useQueryState(field.name, parseAsString.withOptions({ shallow: false }));
+  const [, setParams] = useQueryStates(
+    field.persist === true ? { [field.name]: parseAsString.withOptions({ shallow: false }) } : {},
+  );
 
   const handleChange = useCallback(
     (value: string) => {
-      if (field.persist === true) {
-        void setParam(value);
-      }
-
+      void setParams({ [field.name]: value });
       controls.change(value);
     },
-    [setParam, controls, field.persist],
+    [setParams, field, controls],
   );
 
   const handleOnOptionMouseEnter = (value: string) => {

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -40,7 +40,7 @@ interface State<F extends Field> {
 
 export type ProductDetailFormAction<F extends Field> = Action<State<F>, FormData>;
 
-interface Props<F extends Field> {
+interface Props<F extends Field & { deepLink?: boolean }> {
   fields: F[];
   action: ProductDetailFormAction<F>;
   productId: string;
@@ -194,10 +194,13 @@ function FormField({
 
   const handleChange = useCallback(
     (value: string) => {
-      void setParam(value);
+      if (field.deepLink === true) {
+        void setParam(value);
+      }
+
       controls.change(value);
     },
-    [setParam, controls],
+    [setParam, controls, field.deepLink],
   );
 
   const handleOnOptionMouseEnter = (value: string) => {

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -202,7 +202,9 @@ function FormField({
   );
 
   const handleOnOptionMouseEnter = (value: string) => {
-    onPrefetch(field.name, value);
+    if (field.persist === true) {
+      onPrefetch(field.name, value);
+    }
   };
 
   switch (field.type) {

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -3,6 +3,7 @@
 import {
   FieldMetadata,
   FormProvider,
+  FormStateInput,
   getFormProps,
   SubmissionResult,
   useForm,
@@ -121,6 +122,7 @@ export function ProductDetailForm<F extends Field>({
 
   return (
     <FormProvider context={form.context}>
+      <FormStateInput />
       <form {...getFormProps(form)} action={formAction}>
         <input name="id" type="hidden" value={productId} />
         <div className="space-y-6">

--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -89,7 +89,7 @@ export function ProductDetailForm<F extends Field>({
       ...acc,
       [field.name]: params[field.name] ?? field.defaultValue ?? '',
     }),
-    {},
+    { quantity: 1 },
   );
 
   const [{ lastResult, successMessage }, formAction] = useActionState(action, {

--- a/apps/web/vibes/soul/sections/product-detail/schema.ts
+++ b/apps/web/vibes/soul/sections/product-detail/schema.ts
@@ -5,7 +5,7 @@ interface FormField {
   label?: string;
   errors?: string[];
   required?: boolean;
-  deepLink?: boolean;
+  persist?: boolean;
 }
 
 type RadioField = {

--- a/apps/web/vibes/soul/sections/product-detail/schema.ts
+++ b/apps/web/vibes/soul/sections/product-detail/schema.ts
@@ -5,6 +5,7 @@ interface FormField {
   label?: string;
   errors?: string[];
   required?: boolean;
+  deepLink?: boolean;
 }
 
 type RadioField = {


### PR DESCRIPTION
+ Updated skeletons to prevent issues when importing to Catalyst
+ Add `FormStateInput` to hold state between reload
+ Disable deep linking for non multi select inputs that could fetch new variants.
+ Prevents entire form rerenders when typing on inputs.
+ Also fixes an issue with uncontrolled components when they default to empty string

## Before:
![Screenshot 2024-12-17 at 11 48 26 AM](https://github.com/user-attachments/assets/dc82ddcf-12a6-4319-838e-d514d3c2cb87)

## After:
![Screenshot 2024-12-17 at 11 50 13 AM](https://github.com/user-attachments/assets/d168ed00-88e4-4f55-bcaf-e9cca08b1e2b)
