### PR TITLE
feat: add breadcrumbs as prop to BlogPostContent, make 'author' optional

### DIFF
--- a/apps/web/vibes/soul/examples/pages/blog/post/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/post/electric.tsx
@@ -25,6 +25,21 @@ import {
 import { Facebook, Instagram, X, Youtube } from '@/vibes/soul/sections/footer/social-icons';
 import { Subscribe } from '@/vibes/soul/sections/subscribe';
 
+const breadcrumbs = [
+  {
+    label: 'Home',
+    href: '#',
+  },
+  {
+    label: 'Blog',
+    href: '#',
+  },
+  {
+    label: "Top 5 Plants to Purify Your Home's Air",
+    href: '#',
+  },
+];
+
 const socialMediaLinks = [
   {
     href: '#',
@@ -75,6 +90,7 @@ export default function Preview() {
 
       <BlogPostContent
         author="Sam Smith"
+        breadcrumbs={breadcrumbs}
         content={`
        <h2>Best Air-Purifying Plants</h2>
         <ol>

--- a/apps/web/vibes/soul/examples/pages/blog/post/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/post/luxury.tsx
@@ -25,6 +25,21 @@ import {
 import { Facebook, Instagram, X, Youtube } from '@/vibes/soul/sections/footer/social-icons';
 import { Subscribe } from '@/vibes/soul/sections/subscribe';
 
+const breadcrumbs = [
+  {
+    label: 'Home',
+    href: '#',
+  },
+  {
+    label: 'Blog',
+    href: '#',
+  },
+  {
+    label: "Top 5 Plants to Purify Your Home's Air",
+    href: '#',
+  },
+];
+
 const socialMediaLinks = [
   {
     href: '#',
@@ -75,6 +90,7 @@ export default function Preview() {
 
       <BlogPostContent
         author="Freda Salvador"
+        breadcrumbs={breadcrumbs}
         content={`
        <h2>OCTOBER CAMPAIGN</h2>
        <p>Fall fashion is very much happening and we are very much loving everything. Boots, loafers, leopard print, sweaters, plaid, denim, gold…to name just a few of our favorite things.</p>

--- a/apps/web/vibes/soul/examples/pages/blog/post/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/post/warm.tsx
@@ -25,6 +25,21 @@ import {
 import { Facebook, Instagram, X, Youtube } from '@/vibes/soul/sections/footer/social-icons';
 import { Subscribe } from '@/vibes/soul/sections/subscribe';
 
+const breadcrumbs = [
+  {
+    label: 'Home',
+    href: '#',
+  },
+  {
+    label: 'Blog',
+    href: '#',
+  },
+  {
+    label: "Top 5 Plants to Purify Your Home's Air",
+    href: '#',
+  },
+];
+
 const socialMediaLinks = [
   {
     href: '#',
@@ -75,6 +90,7 @@ export default function Preview() {
 
       <BlogPostContent
         author="Sam Smith"
+        breadcrumbs={breadcrumbs}
         content={`
         <p>A couple weeks ago, we outfitted Chloe and Erik for the their first “official” bikepacking trip - a weekend of camping and riding north from San Francisco to Wildcat Campground, on the Coast Trail in Bolinas. As with any “firsts” like these, there were bound to be some lessons learned along with many pleasant surprises. Chloe wrote the bits below, and they sent along some lovely photos to go along with it. Have a read and hear how it went for these two!</p>
         <p>When your friends snag a last minute campsite at Wildcat, you jump on the offer, no questions asked.  That’s how Erik and I ended up scrambling to prep our newly acquired gravel bikes for our first ~proper~ bikepacking trip. The plan was simple: ride up to Olema from San Francisco on Saturday morning (about 45 miles), hit the Five Brooks trailhead early in the afternoon, and arrive at the coastal campsite an hour or so later.  Since we would only be camping one night and would also be meeting friends who were hiking in, we were able to pack light.  Even so, it took several re-orgs to fit all the essentials: clothes and sandals in the Outer Shell Handlebar bag, tools and food in the Framebag, and sleeping bag, pad, and tent in the Expedition Seatbag.  Once in place, however, the rigs were surprisingly light, maneuverable, and OF COURSE  stylish (camo vs. marigold--who wore it better?!).</p>

--- a/apps/web/vibes/soul/sections/blog-post-content/index.tsx
+++ b/apps/web/vibes/soul/sections/blog-post-content/index.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx';
 import Image from 'next/image';
 
-import { Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
+import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
 
 import { ButtonLink } from '../../primitives/button-link';
 
@@ -20,12 +20,13 @@ interface Image {
 
 interface Props {
   title: string;
-  author: string;
+  author?: string;
   date: string;
   tags?: Tag[];
   content: string;
   image?: Image;
   className?: string;
+  breadcrumbs?: Breadcrumb[];
 }
 
 export const BlogPostContent = function BlogPostContent({
@@ -36,33 +37,24 @@ export const BlogPostContent = function BlogPostContent({
   content,
   image,
   className = '',
+  breadcrumbs,
 }: Props) {
   return (
     <section className={clsx('@container', className)}>
       <div className="mx-auto max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
         <header className="mx-auto w-full max-w-4xl pb-8 @2xl:pb-12 @4xl:pb-16">
-          <Breadcrumbs
-            breadcrumbs={[
-              {
-                label: 'Home',
-                href: '#',
-              },
-              {
-                label: 'Blog',
-                href: '#',
-              },
-              {
-                label: title,
-                href: '#',
-              },
-            ]}
-          />
+          {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} />}
 
           <h1 className="mb-4 mt-8 font-heading text-4xl font-medium leading-none @xl:text-5xl @4xl:text-6xl">
             {title}
           </h1>
           <p>
-            {date} <span className="px-1">•</span> {author}
+            {date}{' '}
+            {Boolean(author) && (
+              <>
+                <span className="px-1">•</span> {author}
+              </>
+            )}
           </p>
 
           {(tags?.length ?? 0) > 0 && (


### PR DESCRIPTION
When working on implementing BlogPostContent into catalyst, I noticed that `breadcrumbs` were always static because it is not a prop on the component.

We should allow breadcrumbs as a prop so that they can be provided to the component.

### Summary
- Add `breadcrumbs` as prop
- Make `author` optional