### PR TITLE
feat: use Stream inside Sorting and update props and focus-visible styles

### DIFF
--- a/apps/web/vibes/soul/form/select/index.tsx
+++ b/apps/web/vibes/soul/form/select/index.tsx
@@ -13,6 +13,7 @@ type Props = {
   name: string;
   placeholder?: string;
   label?: string;
+  hideLabel?: boolean;
   variant?: 'round' | 'rectangle';
   options: Array<{ label: string; value: string }>;
   className?: string;
@@ -24,6 +25,7 @@ type Props = {
 
 export function Select({
   label,
+  hideLabel = false,
   name,
   placeholder = 'Select an item',
   variant = 'rectangle',
@@ -39,8 +41,12 @@ export function Select({
   const id = React.useId();
 
   return (
-    <div className={clsx('space-y-2', className)}>
-      {label !== undefined && label !== '' && <Label htmlFor={id}>{label}</Label>}
+    <div className={className}>
+      {label !== undefined && label !== '' && (
+        <Label className={clsx(hideLabel && 'sr-only', 'mb-2')} htmlFor={id}>
+          {label}
+        </Label>
+      )}
       <SelectPrimitive.Root {...rest} value={value}>
         <SelectPrimitive.Trigger
           aria-label={label}
@@ -67,7 +73,7 @@ export function Select({
             <SelectPrimitive.Viewport>
               {options.map((option) => (
                 <SelectPrimitive.Item
-                  className="w-full cursor-default select-none rounded-xl px-3 py-2 text-sm font-medium text-contrast-400 outline-none transition-colors hover:bg-contrast-100 hover:text-foreground data-[state=checked]:text-foreground @4xl:text-base"
+                  className="w-full cursor-default select-none rounded-xl px-3 py-2 text-sm font-medium text-contrast-400 outline-none transition-colors hover:bg-contrast-100 hover:text-foreground focus-visible:bg-contrast-100 focus-visible:text-foreground data-[state=checked]:text-foreground @4xl:text-base"
                   key={option.value}
                   onMouseEnter={() => {
                     onOptionMouseEnter?.(option.value);

--- a/apps/web/vibes/soul/sections/products-list-section/index.tsx
+++ b/apps/web/vibes/soul/sections/products-list-section/index.tsx
@@ -7,11 +7,14 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { ListProduct, ProductsList } from '@/vibes/soul/primitives/products-list';
 import * as SidePanel from '@/vibes/soul/primitives/side-panel';
-
-import { ProductListTransitionProvider } from './context';
-import { Filter, FiltersPanel } from './filters-panel';
-import { ProductListContainer } from './product-list-container';
-import { Sorting, Option as SortOption } from './sorting';
+import { ProductListTransitionProvider } from '@/vibes/soul/sections/products-list-section/context';
+import { Filter, FiltersPanel } from '@/vibes/soul/sections/products-list-section/filters-panel';
+import { ProductListContainer } from '@/vibes/soul/sections/products-list-section/product-list-container';
+import {
+  Sorting,
+  SortingSkeleton,
+  Option as SortOption,
+} from '@/vibes/soul/sections/products-list-section/sorting';
 
 interface Props {
   breadcrumbs?: Streamable<Breadcrumb[]>;
@@ -27,6 +30,7 @@ interface Props {
   filterLabel?: string;
   resetFiltersLabel?: string;
   sortLabel?: Streamable<string | null>;
+  sortPlaceholder?: Streamable<string | null>;
   sortParamName?: string;
   sortDefaultValue?: string;
   compareParamName?: string;
@@ -41,7 +45,7 @@ export function ProductsListSection({
   totalCount,
   products,
   compareProducts,
-  sortOptions,
+  sortOptions: streamableSortOptions,
   sortDefaultValue,
   filters,
   compareAction,
@@ -49,7 +53,8 @@ export function ProductsListSection({
   paginationInfo,
   filterLabel = 'Filters',
   resetFiltersLabel,
-  sortLabel,
+  sortLabel: streamableSortLabel,
+  sortPlaceholder: streamableSortPlaceholder,
   sortParamName,
   compareParamName,
   emptyStateSubtitle,
@@ -84,12 +89,24 @@ export function ProductsListSection({
                 </Suspense>
               </h1>
               <div className="flex gap-2">
-                <Sorting
-                  defaultValue={sortDefaultValue}
-                  label={sortLabel}
-                  options={sortOptions}
-                  paramName={sortParamName}
-                />
+                <Stream
+                  fallback={<SortingSkeleton />}
+                  value={Promise.all([
+                    streamableSortLabel,
+                    streamableSortOptions,
+                    streamableSortPlaceholder,
+                  ])}
+                >
+                  {([label, options, placeholder]) => (
+                    <Sorting
+                      defaultValue={sortDefaultValue}
+                      label={label}
+                      options={options}
+                      paramName={sortParamName}
+                      placeholder={placeholder}
+                    />
+                  )}
+                </Stream>
                 <div className="block @3xl:hidden">
                   <SidePanel.Root>
                     <SidePanel.Trigger asChild>

--- a/apps/web/vibes/soul/sections/products-list-section/sorting.tsx
+++ b/apps/web/vibes/soul/sections/products-list-section/sorting.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { parseAsString, useQueryState } from 'nuqs';
-import { Suspense, use, useOptimistic } from 'react';
+import { use, useOptimistic } from 'react';
 
 import { Select } from '@/vibes/soul/form/select';
 import { Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
@@ -14,38 +14,17 @@ export interface Option {
 }
 
 export function Sorting({
-  label,
-  options,
+  label: streamableLabel,
+  options: streamableOptions,
   paramName = 'sort',
   defaultValue = '',
+  placeholder: streamablePlaceholder,
 }: {
   label?: Streamable<string | null>;
   options: Streamable<Option[]>;
   paramName?: string;
   defaultValue?: string;
-}) {
-  return (
-    <Suspense fallback={<SortingSkeleton />}>
-      <SortingInner
-        defaultValue={defaultValue}
-        label={label}
-        options={options}
-        paramName={paramName}
-      />
-    </Suspense>
-  );
-}
-
-function SortingInner({
-  paramName,
-  defaultValue,
-  options: streamableOptions,
-  label: streamableLabel,
-}: {
-  paramName: string;
-  defaultValue: string;
-  options: Streamable<Option[]>;
-  label?: Streamable<string | null>;
+  placeholder?: Streamable<string | null>;
 }) {
   const [param, setParam] = useQueryState(
     paramName,
@@ -55,9 +34,11 @@ function SortingInner({
   const [, startTransition] = use(ProductListTransitionContext);
   const options = useStreamable(streamableOptions);
   const label = useStreamable(streamableLabel) ?? 'Sort';
+  const placeholder = useStreamable(streamablePlaceholder) ?? 'Sort by';
 
   return (
     <Select
+      hideLabel
       label={label}
       name={paramName}
       onValueChange={(value) => {
@@ -67,12 +48,13 @@ function SortingInner({
         });
       }}
       options={options}
+      placeholder={placeholder}
       value={optimisticParam}
       variant="round"
     />
   );
 }
 
-function SortingSkeleton() {
+export function SortingSkeleton() {
   return <div className="h-[50px] w-[12ch] animate-pulse rounded-full bg-contrast-100" />;
 }


### PR DESCRIPTION
## What / Why
- Updates `Sorting` component to use `Stream` instead of `Suspense`
- Adds `focus-visible` styles to `SelectPrimitive.Item`
- Updates imports to use `@/vibes`
- Adds `placeholder` prop into `ProductListSection`, `Sorting`, and `Select`
- Adds optional `hideLabel` prop to `Select`
- Passes `Promise.all` into stream values

This component encapsulates `Stream` inside of `Sorting` instead of using `Stream` inside the `ProductsListSection`. Is there a reason we don't do this for the other components like `Breadcrumbs`?

The component rendered inside the `Stream` is called `SortingResolved.` I think this makes the streamable pattern very clear to the user.

## Testing

https://github.com/user-attachments/assets/b333ba91-6c63-41ca-8625-7f9d5bafa30a

