### PR TITLE
feat: address-list-section updates

### DIFF
--- a/apps/web/vibes/soul/examples/sections/address-list-section/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/address-list-section/actions.ts
@@ -1,23 +1,21 @@
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 import { randomUUID } from 'crypto';
-import { z } from 'zod';
 
+import { Address, DefaultAddressConfiguration } from '@/vibes/soul/sections/address-list-section';
 import { schema } from '@/vibes/soul/sections/address-list-section/schema';
-
-type Address = z.infer<typeof schema>;
 
 export async function addressAction(
   prevState: Awaited<{
     addresses: Address[];
     lastResult: SubmissionResult | null;
-    defaultAddressId: string;
+    defaultAddress?: DefaultAddressConfiguration;
   }>,
   formData: FormData,
 ): Promise<{
   addresses: Address[];
   lastResult: SubmissionResult | null;
-  defaultAddressId: string;
+  defaultAddress?: DefaultAddressConfiguration;
 }> {
   'use server';
 
@@ -42,7 +40,7 @@ export async function addressAction(
       return {
         addresses: [...prevState.addresses, newAddress],
         lastResult: submission.reply({ resetForm: true }),
-        defaultAddressId: prevState.defaultAddressId,
+        defaultAddress: prevState.defaultAddress,
       };
     }
     case 'update': {
@@ -54,7 +52,7 @@ export async function addressAction(
           address.id === newAddress.id ? newAddress : address,
         ),
         lastResult: submission.reply({ resetForm: true }),
-        defaultAddressId: prevState.defaultAddressId,
+        defaultAddress: prevState.defaultAddress,
       };
     }
     case 'delete': {
@@ -64,7 +62,7 @@ export async function addressAction(
       return {
         addresses: prevState.addresses.filter((address) => address.id !== deletedAddress.id),
         lastResult: submission.reply({ resetForm: true }),
-        defaultAddressId: prevState.defaultAddressId,
+        defaultAddress: prevState.defaultAddress,
       };
     }
     case 'setDefault': {
@@ -74,7 +72,7 @@ export async function addressAction(
       return {
         addresses: prevState.addresses,
         lastResult: submission.reply({ resetForm: true }),
-        defaultAddressId: defaultAddress.id,
+        defaultAddress: { id: defaultAddress.id },
       };
     }
     default: {

--- a/apps/web/vibes/soul/examples/sections/address-list-section/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/address-list-section/index.tsx
@@ -39,7 +39,7 @@ export default function Preview() {
       <AddressListSection
         addressAction={addressAction}
         addresses={addresses}
-        defaultAddressId="1"
+        defaultAddress={{ id: '1' }}
       />
     </AccountLayout>
   );

--- a/apps/web/vibes/soul/sections/address-list-section/index.tsx
+++ b/apps/web/vibes/soul/sections/address-list-section/index.tsx
@@ -30,6 +30,7 @@ interface State<A extends Address> {
 interface Props<A extends Address> {
   title?: string;
   addresses: A[];
+  minimumAddressCount?: number;
   defaultAddress?: DefaultAddressConfiguration;
   addressAction: Action<State<A>, FormData>;
   editLabel?: string;
@@ -54,6 +55,7 @@ interface Props<A extends Address> {
 export function AddressListSection<A extends Address>({
   title = 'Addresses',
   addresses,
+  minimumAddressCount = 1,
   defaultAddress,
   addressAction,
   editLabel = 'Edit',
@@ -226,20 +228,23 @@ export function AddressListSection<A extends Address>({
                   >
                     {editLabel}
                   </Button>
-                  <AddressActionButton
-                    action={formAction}
-                    address={address}
-                    aria-label={`${deleteLabel}: ${address.firstName} ${address.lastName}`}
-                    intent="delete"
-                    onSubmit={(formData) => {
-                      startTransition(() => {
-                        formAction(formData);
-                        setOptimisticState(formData);
-                      });
-                    }}
-                  >
-                    {deleteLabel}
-                  </AddressActionButton>
+                  {optimisticState.addresses.length > minimumAddressCount && (
+                    <AddressActionButton
+                      action={formAction}
+                      address={address}
+                      aria-label={`${deleteLabel}: ${address.firstName} ${address.lastName}`}
+                      intent="delete"
+                      onSubmit={(formData) => {
+                        startTransition(() => {
+                          formAction(formData);
+                          setOptimisticState(formData);
+                        });
+                      }}
+                    >
+                      {deleteLabel}
+                    </AddressActionButton>
+                  )}
+
                   {optimisticState.defaultAddress &&
                     optimisticState.defaultAddress.id !== address.id && (
                       <AddressActionButton


### PR DESCRIPTION
## What/why?

> [!TIP]
> Hide whitespace might help reviewing.

Adds two bits of functionality to the `AddressListSection` component:
- Makes setting the default address optional as some systems may not have that ability.
- Adds a `minimumAddressCount` prop to enforce how many addresses can be deleted.

### Set Default Logic
Below is the matrix on the prop logic:
| `defaultAddress` value | Functionality |
| ----------------------- | ------------- |
| `undefined`                   | No default address functionality will be shown |
| `{ id: null }`                    | Shows the `Set Default` button in a situation where a customer doesn't have a default address set |
| `{ id: '1' }`                     | Renders the `Set Default` button on every address that is not the default. Shows the default label on the default address. |

## Testing

### Set Default Logic:
![Screenshot 2024-12-18 at 15 26 57](https://github.com/user-attachments/assets/a31ff0ac-c736-4160-bdd8-b74b3028720b)
![Screenshot 2024-12-18 at 15 27 10](https://github.com/user-attachments/assets/56f9f5fb-efa7-4824-8615-07acc837d0e5)
![Screenshot 2024-12-18 at 15 27 23](https://github.com/user-attachments/assets/efa275cb-36ee-4fa1-931a-e727397d58a6)

### Minimum Address Count:

https://github.com/user-attachments/assets/2fa80ce7-5dc2-4a4a-b64c-9a2c9ac76856


