### PR TITLE
Fix image priority on PLP to improve lighthouse

### DIFF
--- a/apps/web/vibes/soul/primitives/products-list/index.tsx
+++ b/apps/web/vibes/soul/primitives/products-list/index.tsx
@@ -60,7 +60,7 @@ export function ProductsList({
           return (
             <div className={clsx('w-full @container', className)}>
               <div className="mx-auto grid grid-cols-1 gap-x-4 gap-y-6 @sm:grid-cols-2 @2xl:grid-cols-3 @2xl:gap-x-5 @2xl:gap-y-8 @5xl:grid-cols-4 @7xl:grid-cols-5">
-                {products.map((product) => (
+                {products.map((product, index) => (
                   <ProductCard
                     aspectRatio={aspectRatio}
                     colorScheme={colorScheme}
@@ -69,6 +69,7 @@ export function ProductsList({
                     key={product.id}
                     product={product}
                     showCompare={showCompare}
+                    imagePriority={index === 0}
                   />
                 ))}
               </div>


### PR DESCRIPTION
Mirroring https://github.com/bigcommerce/catalyst/pull/1781

## What/Why?
Improve lighthouse finding around above-the-fold image being loaded lazily; prioritizing just the first image is enough to eliminate the finding and maps to the mobile experience where you can only see one image. On desktop this might ideally be more like the first 3-4 images, but the finding on desktop goes away also so I'm fine to start with 1 image.

## Testing
Before:

<img width="851" alt="image" src="https://github.com/user-attachments/assets/00abb299-88ae-482c-8d8f-7758092f7469" />

After (finding gone):

<img width="836" alt="image" src="https://github.com/user-attachments/assets/10abfddf-a442-4b5c-93d6-793c12a2e214" />
