### PR TITLE
fix: delete wrapping component in Reviews

### DIFF
--- a/apps/web/vibes/soul/sections/reviews/index.tsx
+++ b/apps/web/vibes/soul/sections/reviews/index.tsx
@@ -1,5 +1,3 @@
-import { Suspense } from 'react';
-
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Rating } from '@/vibes/soul/primitives/rating';
@@ -22,7 +20,7 @@ interface Props {
   reviewsLabel?: string;
 }
 
-async function ReviewsImpl({
+export function Reviews({
   reviews: streamableReviews,
   averageRating: streamableAverageRating,
   totalCount: streamableTotalCount,
@@ -30,72 +28,76 @@ async function ReviewsImpl({
   emptyStateMessage,
   reviewsLabel = 'Reviews',
 }: Readonly<Props>) {
-  const reviews = await streamableReviews;
-
-  if (reviews.length === 0)
-    return <ReviewsEmptyState message={emptyStateMessage} reviewsLabel={reviewsLabel} />;
-
   return (
-    <StickySidebarLayout
-      sidebar={
-        <>
-          <Stream
-            fallback={
-              <div className="animate-pulse">
-                <h2 className="mb-4 mt-0 text-xl font-medium @xl:my-5 @xl:text-2xl">
-                  {reviewsLabel}
-                </h2>
-              </div>
-            }
-            value={streamableTotalCount}
-          >
-            {(totalCount) => (
-              <h2 className="mb-4 mt-0 text-xl font-medium @xl:my-5 @xl:text-2xl">
-                {reviewsLabel} <span className="text-contrast-300">{totalCount}</span>
-              </h2>
-            )}
-          </Stream>
-          <Stream
-            fallback={
-              <div className="animate-pulse">
-                <div className="mb-2 h-[1lh] w-[3ch] rounded-md bg-contrast-100 font-heading text-5xl leading-none tracking-tighter @2xl:text-6xl" />
-                <div className="h-5 w-32 rounded-md bg-contrast-100" />
-              </div>
-            }
-            value={streamableAverageRating}
-          >
-            {(averageRating) => (
-              <>
-                <div className="mb-2 font-heading text-5xl leading-none tracking-tighter @2xl:text-6xl">
-                  {averageRating}
-                </div>
-                <Rating rating={averageRating} showRating={false} />
-              </>
-            )}
-          </Stream>
-        </>
-      }
-      sidebarSize="medium"
-    >
-      <div className="flex-1 border-t border-contrast-100">
-        {reviews.map(({ id, rating, review, name, date }) => {
-          return (
-            <div className="border-b border-contrast-100 py-6" key={id}>
-              <Rating rating={rating} />
-              <p className="mt-5 text-lg font-semibold text-foreground">{name}</p>
-              <p className="mb-8 mt-2 leading-normal text-contrast-500">{review}</p>
-              <p className="text-sm text-contrast-500">{date}</p>
-            </div>
-          );
-        })}
+    <Stream fallback={<ReviewsSkeleton reviewsLabel={reviewsLabel} />} value={streamableReviews}>
+      {(reviews) => {
+        if (reviews.length === 0)
+          return <ReviewsEmptyState message={emptyStateMessage} reviewsLabel={reviewsLabel} />;
 
-        <Stream value={streamablePaginationInfo}>
-          {(paginationInfo) =>
-            paginationInfo && <CursorPagination info={paginationInfo} scroll={false} />
-          }
-        </Stream>
-      </div>
-    </StickySidebarLayout>
+        return (
+          <StickySidebarLayout
+            sidebar={
+              <>
+                <Stream
+                  fallback={
+                    <div className="animate-pulse">
+                      <h2 className="mb-4 mt-0 text-xl font-medium @xl:my-5 @xl:text-2xl">
+                        {reviewsLabel}
+                      </h2>
+                    </div>
+                  }
+                  value={streamableTotalCount}
+                >
+                  {(totalCount) => (
+                    <h2 className="mb-4 mt-0 text-xl font-medium @xl:my-5 @xl:text-2xl">
+                      {reviewsLabel} <span className="text-contrast-300">{totalCount}</span>
+                    </h2>
+                  )}
+                </Stream>
+                <Stream
+                  fallback={
+                    <div className="animate-pulse">
+                      <div className="mb-2 h-[1lh] w-[3ch] rounded-md bg-contrast-100 font-heading text-5xl leading-none tracking-tighter @2xl:text-6xl" />
+                      <div className="h-5 w-32 rounded-md bg-contrast-100" />
+                    </div>
+                  }
+                  value={streamableAverageRating}
+                >
+                  {(averageRating) => (
+                    <>
+                      <div className="mb-2 font-heading text-5xl leading-none tracking-tighter @2xl:text-6xl">
+                        {averageRating}
+                      </div>
+                      <Rating rating={averageRating} showRating={false} />
+                    </>
+                  )}
+                </Stream>
+              </>
+            }
+            sidebarSize="medium"
+          >
+            <div className="flex-1 border-t border-contrast-100">
+              {reviews.map(({ id, rating, review, name, date }) => {
+                return (
+                  <div className="border-b border-contrast-100 py-6" key={id}>
+                    <Rating rating={rating} />
+                    <p className="mt-5 text-lg font-semibold text-foreground">{name}</p>
+                    <p className="mb-8 mt-2 leading-normal text-contrast-500">{review}</p>
+                    <p className="text-sm text-contrast-500">{date}</p>
+                  </div>
+                );
+              })}
+
+              <Stream value={streamablePaginationInfo}>
+                {(paginationInfo) =>
+                  paginationInfo && <CursorPagination info={paginationInfo} scroll={false} />
+                }
+              </Stream>
+            </div>
+          </StickySidebarLayout>
+        );
+      }}
+    </Stream>
   );
 }
 
@@ -151,13 +153,5 @@ export function ReviewsSkeleton({ reviewsLabel = 'Reviews' }: { reviewsLabel?: s
         ))}
       </div>
     </StickySidebarLayout>
-  );
-}
-
-export function Reviews({ reviewsLabel = 'Reviews', ...props }: Props) {
-  return (
-    <Suspense fallback={<ReviewsSkeleton reviewsLabel={reviewsLabel} />}>
-      <ReviewsImpl {...props} reviewsLabel={reviewsLabel} />
-    </Suspense>
   );
 }


### PR DESCRIPTION
With the `Stream` pattern, having a wrapping component is not needed.