### PR TITLE
fix: add max-width to ProductDetails

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -128,26 +128,14 @@ export function ProductDetail<F extends Field>({
                   </Stream>
 
                   <Stream fallback={<ProductDescriptionSkeleton />} value={product.description}>
-                    {(description) => {
-                      if (description === null || description === undefined) {
-                        return null;
-                      }
-
-                      if (typeof description === 'string') {
-                        return (
-                          <p className="border-y border-contrast-100 py-8 text-contrast-500">
-                            {description}
-                          </p>
-                        );
-                      }
-
-                      return (
-                        <div
-                          className="border-t border-contrast-100 py-8 text-contrast-500"
-                          dangerouslySetInnerHTML={{ __html: description }}
-                        />
-                      );
-                    }}
+                    {(description) =>
+                      description !== null &&
+                      description !== undefined && (
+                        <div className="border-t border-contrast-100 py-8 text-contrast-500">
+                          {description}
+                        </div>
+                      )
+                    }
                   </Stream>
 
                   <Stream fallback={<ProductAccordionsSkeleton />} value={product.accordions}>

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -129,8 +129,7 @@ export function ProductDetail<F extends Field>({
 
                   <Stream fallback={<ProductDescriptionSkeleton />} value={product.description}>
                     {(description) =>
-                      description !== null &&
-                      description !== undefined && (
+                      description != null && (
                         <div className="border-t border-contrast-100 py-8 text-contrast-500">
                           {description}
                         </div>

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -143,7 +143,7 @@ export function ProductDetail<F extends Field>({
 
                       return (
                         <div
-                          className="border-top border-contrast-100 py-8 text-contrast-500"
+                          className="border-t border-contrast-100 py-8 text-contrast-500"
                           dangerouslySetInnerHTML={{ __html: description }}
                         />
                       );
@@ -153,7 +153,7 @@ export function ProductDetail<F extends Field>({
                   <Stream fallback={<ProductAccordionsSkeleton />} value={product.accordions}>
                     {(accordions) =>
                       accordions && (
-                        <Accordions className="border-top border-contrast-100 pt-4" type="multiple">
+                        <Accordions className="border-t border-contrast-100 pt-4" type="multiple">
                           {accordions.map((accordion, index) => (
                             <Accordion key={index} title={accordion.title} value={index.toString()}>
                               {accordion.content}

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -56,7 +56,7 @@ export function ProductDetail<F extends Field>({
 }: Props<F>) {
   return (
     <section className="@container">
-      <div className="mx-auto w-full px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
+      <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
         {breadcrumbs && <Breadcrumbs breadcrumbs={breadcrumbs} className="mb-6" />}
 
         <Stream fallback={<ProductDetailSkeleton />} value={streamableProduct}>


### PR DESCRIPTION
I accidentally removed it when I just needed to change the max-width to match the new designs:

## Before
![screencapture-localhost-3000-docs-soul-product-detail-2024-12-20-15_29_20](https://github.com/user-attachments/assets/3d869ba4-1ef4-4885-8989-15535484541b)

## After
![screencapture-localhost-3000-docs-soul-product-detail-2024-12-20-15_29_51](https://github.com/user-attachments/assets/e91ac5bd-1a48-4bf6-8c8c-0774fcf4d85d)
