### PR TITLE
feat: add Skeleton component and SkeletonWrapper component

### DIFF
--- a/apps/web/vibes/soul/examples/primitives/products-carousel/electric.tsx
+++ b/apps/web/vibes/soul/examples/primitives/products-carousel/electric.tsx
@@ -1,4 +1,5 @@
 import { CarouselProduct, ProductsCarousel } from '@/vibes/soul/primitives/products-carousel';
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
   const products = new Promise<CarouselProduct[]>((resolve) => {
@@ -7,16 +8,16 @@ export default function Preview() {
 
   return (
     <div>
-      <section className="overflow-hidden @container">
+      <SectionLayout className="group/products-carousel">
         <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
           <ProductsCarousel products={products} />
         </div>
-      </section>
-      <section className="overflow-hidden bg-foreground @container">
+      </SectionLayout>
+      <SectionLayout className="group/products-carousel bg-foreground">
         <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
           <ProductsCarousel colorScheme="dark" products={products} showScrollbar={false} />
         </div>
-      </section>
+      </SectionLayout>
     </div>
   );
 }

--- a/apps/web/vibes/soul/examples/primitives/products-carousel/luxury.tsx
+++ b/apps/web/vibes/soul/examples/primitives/products-carousel/luxury.tsx
@@ -1,4 +1,5 @@
 import { CarouselProduct, ProductsCarousel } from '@/vibes/soul/primitives/products-carousel';
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
   const products = new Promise<CarouselProduct[]>((resolve) => {
@@ -7,16 +8,16 @@ export default function Preview() {
 
   return (
     <div>
-      <section className="overflow-hidden @container">
+      <SectionLayout className="group/products-carousel">
         <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
           <ProductsCarousel products={products} />
         </div>
-      </section>
-      <section className="overflow-hidden bg-foreground @container">
+      </SectionLayout>
+      <SectionLayout className="group/products-carousel bg-foreground">
         <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
           <ProductsCarousel colorScheme="dark" products={products} showScrollbar={false} />
         </div>
-      </section>
+      </SectionLayout>
     </div>
   );
 }

--- a/apps/web/vibes/soul/examples/primitives/products-carousel/warm.tsx
+++ b/apps/web/vibes/soul/examples/primitives/products-carousel/warm.tsx
@@ -1,4 +1,5 @@
 import { CarouselProduct, ProductsCarousel } from '@/vibes/soul/primitives/products-carousel';
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
   const products = new Promise<CarouselProduct[]>((resolve) => {
@@ -7,16 +8,16 @@ export default function Preview() {
 
   return (
     <div>
-      <section className="overflow-hidden @container">
+      <SectionLayout className="group/products-carousel">
         <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
           <ProductsCarousel products={products} />
         </div>
-      </section>
-      <section className="overflow-hidden bg-foreground @container">
+      </SectionLayout>
+      <SectionLayout className="group/products-carousel bg-foreground">
         <div className="mx-auto w-full max-w-screen-2xl px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20">
           <ProductsCarousel colorScheme="dark" products={products} showScrollbar={false} />
         </div>
-      </section>
+      </SectionLayout>
     </div>
   );
 }

--- a/apps/web/vibes/soul/primitives/card-carousel/index.tsx
+++ b/apps/web/vibes/soul/primitives/card-carousel/index.tsx
@@ -10,7 +10,7 @@ import {
   CarouselItem,
   CarouselScrollbar,
 } from '@/vibes/soul/primitives/carousel';
-
+import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 export type Card = CardProps & {
   id: string;
 };
@@ -22,8 +22,8 @@ export interface CardCarouselProps {
   iconColorScheme?: 'light' | 'dark';
   carouselColorScheme?: 'light' | 'dark';
   className?: string;
-  emptyStateTitle?: Streamable<string | null>;
-  emptyStateSubtitle?: Streamable<string | null>;
+  emptyStateTitle?: Streamable<string>;
+  emptyStateSubtitle?: Streamable<string>;
   scrollbarLabel?: string;
   previousLabel?: string;
   nextLabel?: string;
@@ -133,10 +133,10 @@ export function CardCarouselSkeleton({
         </div>
       </div>
       <div className="mt-10 flex w-full items-center justify-between gap-8">
-        <div className="h-1 w-full max-w-56 rounded bg-contrast-100" />
+        <Skeleton.Box className="h-1 w-full max-w-56 rounded" />
         <div className="flex gap-2 text-contrast-200">
-          <ArrowLeft className="h-6 w-6" strokeWidth={1.5} />
-          <ArrowRight className="h-6 w-6" strokeWidth={1.5} />
+          <Skeleton.Icon icon={<ArrowLeft aria-hidden className="h-6 w-6" strokeWidth={1.5} />} />
+          <Skeleton.Icon icon={<ArrowRight aria-hidden className="h-6 w-6" strokeWidth={1.5} />} />
         </div>
       </div>
     </div>
@@ -152,8 +152,8 @@ export function CardCarouselEmptyState({
 }: {
   className?: string;
   placeholderCount?: number;
-  emptyStateTitle?: Streamable<string | null>;
-  emptyStateSubtitle?: Streamable<string | null>;
+  emptyStateTitle?: Streamable<string>;
+  emptyStateSubtitle?: Streamable<string>;
   hideOverflow?: boolean;
 }) {
   return (

--- a/apps/web/vibes/soul/primitives/card/index.tsx
+++ b/apps/web/vibes/soul/primitives/card/index.tsx
@@ -3,6 +3,8 @@ import { ArrowUpRight } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
+import * as Skeleton from '@/vibes/soul/primitives/skeleton';
+
 export interface CardProps {
   className?: string;
   title: string;
@@ -123,9 +125,9 @@ export function CardSkeleton({
 }) {
   return (
     <div className={clsx('@container', className)}>
-      <div
+      <Skeleton.Box
         className={clsx(
-          'rounded-[var(--card-border-radius,1rem)] bg-contrast-100',
+          'rounded-[var(--card-border-radius,1rem)]',
           {
             '5:6': 'aspect-[5/6]',
             '3:4': 'aspect-[3/4]',
@@ -133,10 +135,8 @@ export function CardSkeleton({
           }[aspectRatio],
         )}
       />
-      <div className="mt-3 text-lg">
-        <div className="flex h-[1lh] items-center">
-          <span className="block h-[1ex] w-[10ch] rounded-sm bg-contrast-100" />
-        </div>
+      <div className="mt-3">
+        <Skeleton.Text className="rounded text-lg" characterCount={10} />
       </div>
     </div>
   );

--- a/apps/web/vibes/soul/primitives/product-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/index.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 
 import { Badge } from '@/vibes/soul/primitives/badge';
 import { Price, PriceLabel } from '@/vibes/soul/primitives/price-label';
+import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 import { Compare } from './compare';
 
@@ -172,9 +173,9 @@ export function ProductCardSkeleton({
 }) {
   return (
     <div className={clsx('@container', className)}>
-      <div
+      <Skeleton.Box
         className={clsx(
-          'flex flex-col gap-2 rounded-xl bg-contrast-100 @md:rounded-2xl',
+          'rounded-xl @md:rounded-2xl',
           {
             '5:6': 'aspect-[5/6]',
             '3:4': 'aspect-[3/4]',
@@ -183,18 +184,10 @@ export function ProductCardSkeleton({
         )}
       />
       <div className="mt-2 flex flex-col items-start gap-x-4 gap-y-3 px-1 @xs:mt-3 @2xl:flex-row">
-        <div className="flex-1">
-          <div className="flex flex-col text-base">
-            <div className="flex h-[1lh] items-center">
-              <span className="block h-[1ex] w-[10ch] rounded-sm bg-contrast-100" />
-            </div>
-            <div className="mb-2 flex h-[1lh] items-center text-sm font-normal text-contrast-400">
-              <span className="block h-[1ex] w-[8ch] rounded-sm bg-contrast-100" />
-            </div>
-            <div className="flex h-[1lh] items-center">
-              <span className="block h-[1ex] w-[5ch] rounded-sm bg-contrast-100" />
-            </div>
-          </div>
+        <div className="w-full text-base">
+          <Skeleton.Text className="rounded" characterCount={10} />
+          <Skeleton.Text className="rounded" characterCount={8} />
+          <Skeleton.Text className="rounded" characterCount={6} />
         </div>
       </div>
     </div>

--- a/apps/web/vibes/soul/primitives/products-carousel/index.tsx
+++ b/apps/web/vibes/soul/primitives/products-carousel/index.tsx
@@ -14,6 +14,7 @@ import {
   ProductCard,
   ProductCardSkeleton,
 } from '@/vibes/soul/primitives/product-card';
+import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 export type CarouselProduct = CardProduct;
 
@@ -124,9 +125,13 @@ export function ProductsCarouselSkeleton({
   hideOverflow?: boolean;
 }) {
   return (
-    <div
-      className={clsx('@container', hideOverflow && 'overflow-hidden', className)}
-      data-pending={pending ? '' : undefined}
+    <Skeleton.Root
+      className={clsx(
+        'group-has-[[data-pending]]/products-carousel:animate-pulse',
+        hideOverflow && 'overflow-hidden',
+        className,
+      )}
+      pending={pending}
     >
       <div className="w-full">
         <div className="-ml-4 flex @2xl:-ml-5">
@@ -141,13 +146,13 @@ export function ProductsCarouselSkeleton({
         </div>
       </div>
       <div className="mt-10 flex w-full items-center justify-between gap-8">
-        <div className="h-1 w-full max-w-56 rounded bg-contrast-100" />
-        <div className="flex gap-2 text-contrast-200">
-          <ArrowLeft className="h-6 w-6" strokeWidth={1.5} />
-          <ArrowRight className="h-6 w-6" strokeWidth={1.5} />
+        <Skeleton.Box className="h-1 w-56 rounded" />
+        <div className="flex gap-2">
+          <Skeleton.Icon icon={<ArrowLeft aria-hidden className="h-6 w-6" strokeWidth={1.5} />} />
+          <Skeleton.Icon icon={<ArrowRight aria-hidden className="h-6 w-6" strokeWidth={1.5} />} />
         </div>
       </div>
-    </div>
+    </Skeleton.Root>
   );
 }
 

--- a/apps/web/vibes/soul/primitives/products-list/index.tsx
+++ b/apps/web/vibes/soul/primitives/products-list/index.tsx
@@ -137,7 +137,7 @@ export function ProductsListEmptyState({
       </div>
       <div className="absolute inset-0 mx-auto px-3 py-16 pb-3 @4xl:px-10 @4xl:pb-10 @4xl:pt-28">
         <div className="mx-auto max-w-xl space-y-2 text-center @4xl:space-y-3">
-          <h3 className="@4x:leading-none font-heading text-2xl leading-tight text-foreground @4xl:text-4xl">
+          <h3 className="font-heading text-2xl leading-tight text-foreground @4xl:text-4xl @4xl:leading-none">
             {emptyStateTitle}
           </h3>
           <p className="text-sm text-contrast-500 @4xl:text-lg">{emptyStateSubtitle}</p>

--- a/apps/web/vibes/soul/primitives/skeleton/index.tsx
+++ b/apps/web/vibes/soul/primitives/skeleton/index.tsx
@@ -1,0 +1,66 @@
+import { clsx } from 'clsx';
+import { ReactNode } from 'react';
+
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --skeleton: color-mix(in oklab, hsl(var(--contast-300)), white 75%);
+ * }
+ * ```
+ */
+function SkeletonRoot({
+  className,
+  children,
+  pending = false,
+}: {
+  className?: string;
+  children?: React.ReactNode;
+  pending: boolean;
+}) {
+  return (
+    <div
+      className={clsx('@container', className)}
+      data-pending={pending ? '' : undefined}
+      role={pending ? 'status' : undefined}
+    >
+      {children}
+      {pending && <span className="sr-only">Loading...</span>}
+    </div>
+  );
+}
+
+function SkeletonBox({ className }: { className?: string }) {
+  return <div className={clsx('bg-[var(--skeleton,hsl(var(--contrast-300)/15%))]', className)} />;
+}
+
+function SkeletonText({
+  characterCount = 10,
+  className,
+}: {
+  characterCount?: number | 'full';
+  className?: string;
+}) {
+  return (
+    <div className={clsx('flex h-[1lh] items-center', className)}>
+      <div
+        className={clsx(
+          `h-[1ex] max-w-full rounded-[inherit] bg-[var(--skeleton,hsl(var(--contrast-300)/15%))]`,
+          characterCount === 'full' ? 'w-full' : `w-[${characterCount}ch]`,
+        )}
+      />
+    </div>
+  );
+}
+
+function SkeletonIcon({ className, icon }: { className?: string; icon: ReactNode }) {
+  return (
+    <div className={clsx('text-[var(--skeleton,hsl(var(--contrast-300)))] opacity-25', className)}>
+      {icon}
+    </div>
+  );
+}
+
+export { SkeletonIcon as Icon, SkeletonRoot as Root, SkeletonBox as Box, SkeletonText as Text };

--- a/apps/web/vibes/soul/sections/featured-products-carousel/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-products-carousel/index.tsx
@@ -34,7 +34,7 @@ export function FeaturedProductsCarousel({
   nextLabel,
 }: Props) {
   return (
-    <SectionLayout className="group/pending" hideOverflow>
+    <SectionLayout className="group/products-carousel">
       <div className="mb-6 flex w-full flex-row flex-wrap items-end justify-between gap-x-8 gap-y-6 text-foreground @4xl:mb-8">
         <div>
           <h2 className="font-heading text-2xl leading-none @xl:text-3xl @4xl:text-4xl">{title}</h2>
@@ -47,18 +47,16 @@ export function FeaturedProductsCarousel({
           <AnimatedLink className="mr-3" label={cta.label} link={{ href: cta.href }} />
         )}
       </div>
-      <div className="group-has-[[data-pending]]/pending:animate-pulse">
-        <ProductsCarousel
-          emptyStateSubtitle={emptyStateSubtitle}
-          emptyStateTitle={emptyStateTitle}
-          hideOverflow={false}
-          nextLabel={nextLabel}
-          placeholderCount={placeholderCount}
-          previousLabel={previousLabel}
-          products={products}
-          scrollbarLabel={scrollbarLabel}
-        />
-      </div>
+      <ProductsCarousel
+        emptyStateSubtitle={emptyStateSubtitle}
+        emptyStateTitle={emptyStateTitle}
+        hideOverflow={false}
+        nextLabel={nextLabel}
+        placeholderCount={placeholderCount}
+        previousLabel={previousLabel}
+        products={products}
+        scrollbarLabel={scrollbarLabel}
+      />
     </SectionLayout>
   );
 }

--- a/apps/web/vibes/soul/sections/featured-products-list/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-products-list/index.tsx
@@ -29,6 +29,7 @@ export function FeaturedProductsList({
 }: Props) {
   return (
     <StickySidebarLayout
+      className="group/products-list"
       sidebar={
         <>
           <h2 className="mb-3 font-heading text-4xl font-medium leading-none text-foreground @4xl:text-5xl">
@@ -49,15 +50,13 @@ export function FeaturedProductsList({
       }
       sidebarSize="1/3"
     >
-      <div className="group-has-[[data-pending]]/pending:animate-pulse">
-        <ProductsList
-          className="flex-1"
-          emptyStateSubtitle={emptyStateSubtitle}
-          emptyStateTitle={emptyStateTitle}
-          placeholderCount={placeholderCount}
-          products={products}
-        />
-      </div>
+      <ProductsList
+        className="flex-1"
+        emptyStateSubtitle={emptyStateSubtitle}
+        emptyStateTitle={emptyStateTitle}
+        placeholderCount={placeholderCount}
+        products={products}
+      />
     </StickySidebarLayout>
   );
 }

--- a/apps/web/vibes/soul/sections/section-layout/index.tsx
+++ b/apps/web/vibes/soul/sections/section-layout/index.tsx
@@ -17,15 +17,13 @@ export function SectionLayout({
   className,
   children,
   containerSize = '2xl',
-  hideOverflow = false,
 }: {
   className?: string;
   children: React.ReactNode;
   containerSize?: 'md' | 'lg' | 'xl' | '2xl';
-  hideOverflow?: boolean;
 }) {
   return (
-    <section className={clsx('@container', hideOverflow && 'overflow-hidden', className)}>
+    <section className={clsx('@container', className)}>
       <div
         className={clsx(
           'mx-auto px-4 py-10 @xl:px-6 @xl:py-14 @4xl:px-8 @4xl:py-20',


### PR DESCRIPTION
## What/Why
This PR introduces a `Skeleton` primitive to VIBES that will help streamline the creation of skeleton loaders across the project. I'm also proposing a `Skeleton.Root` component to simplify creating component skeletons because it automatically handles accessibility and the `data-pending` pattern to handle skeleton animations.

This PR also promotes the `ProductsCarousel` to a section after discussing with the team that primitives should only be responsible for rendering data and that primitives should not compose other primitives.

### Skeleton component
- Provides `Skelton.Root` `Skeleton.Text` `Skelton.Box` and `Skeleton.Icon` components
- Simplifies the process of making skeletons accessible
- Relies on Tailwind classes to style the component rather than props that control the styles
- `characterCount` prop on `Skeleton.Text` to simplify how we're using `ch` to style
- Changed default skeleton color so it looks better on a larger range of backgrounds 

## Testing


https://github.com/user-attachments/assets/a656858d-d741-46bd-aae4-a10afa09178e



