### PR TITLE
feat(orders): update orders-list component

### DIFF
--- a/apps/web/vibes/soul/sections/order-list-section/index.tsx
+++ b/apps/web/vibes/soul/sections/order-list-section/index.tsx
@@ -7,15 +7,30 @@ interface Props {
   title?: string;
   orders: Order[] | Promise<Order[]>;
   paginationInfo?: CursorPaginationInfo | Promise<CursorPaginationInfo>;
+  orderNumberLabel?: string;
+  totalLabel?: string;
+  viewDetailsLabel?: string;
 }
 
-export function OrderListSection({ title = 'Orders', orders, paginationInfo }: Props) {
+export function OrderListSection({
+  title = 'Orders',
+  orders,
+  paginationInfo,
+  orderNumberLabel,
+  totalLabel,
+  viewDetailsLabel,
+}: Props) {
   return (
     <div className="@container">
       <h1 className="mb-8 hidden text-4xl font-medium leading-tight tracking-tight @2xl:block">
         {title}
       </h1>
-      <OrderList orders={orders} />
+      <OrderList
+        orderNumberLabel={orderNumberLabel}
+        orders={orders}
+        totalLabel={totalLabel}
+        viewDetailsLabel={viewDetailsLabel}
+      />
       {paginationInfo && <CursorPagination info={paginationInfo} />}
     </div>
   );

--- a/apps/web/vibes/soul/sections/order-list-section/order-list-item.tsx
+++ b/apps/web/vibes/soul/sections/order-list-section/order-list-item.tsx
@@ -16,9 +16,18 @@ export interface Order {
 interface Props {
   className?: string;
   order: Order;
+  orderNumberLabel?: string;
+  totalLabel?: string;
+  viewDetailsLabel?: string;
 }
 
-export function OrderListItem({ className, order }: Props) {
+export function OrderListItem({
+  className,
+  order,
+  orderNumberLabel = 'Order #',
+  totalLabel = 'Total',
+  viewDetailsLabel = 'View details',
+}: Props) {
   return (
     <div
       className={clsx(
@@ -30,13 +39,13 @@ export function OrderListItem({ className, order }: Props) {
         <div className="flex items-start gap-x-12">
           <div>
             <span className="font-mono text-xs uppercase leading-normal text-contrast-500">
-              Order #
+              {orderNumberLabel}
             </span>
             <span className="block text-lg font-semibold leading-normal">{order.id}</span>
           </div>
           <div>
             <span className="font-mono text-xs uppercase leading-normal text-contrast-500">
-              Total
+              {totalLabel}
             </span>
             <span className="block text-lg font-semibold leading-normal">{order.totalPrice}</span>
           </div>
@@ -44,7 +53,7 @@ export function OrderListItem({ className, order }: Props) {
         </div>
 
         <ButtonLink href={order.href} size="small">
-          View details
+          {viewDetailsLabel}
         </ButtonLink>
       </div>
 

--- a/apps/web/vibes/soul/sections/order-list-section/order-list-line-item.tsx
+++ b/apps/web/vibes/soul/sections/order-list-section/order-list-line-item.tsx
@@ -48,9 +48,9 @@ export function OrderListLineItem({ className, lineItem }: Props) {
         <span className="block font-semibold">{lineItem.title}</span>
 
         {lineItem.subtitle != null && lineItem.subtitle !== '' && (
-          <span className="mb-1.5 block font-normal text-contrast-400">{lineItem.subtitle}</span>
+          <span className="block font-normal text-contrast-400">{lineItem.subtitle}</span>
         )}
-        <PriceLabel price={lineItem.price} />
+        <PriceLabel className="mt-1.5" price={lineItem.price} />
       </div>
     </Link>
   );

--- a/apps/web/vibes/soul/sections/order-list-section/order-list.tsx
+++ b/apps/web/vibes/soul/sections/order-list-section/order-list.tsx
@@ -4,6 +4,9 @@ import { Order, OrderListItem } from './order-list-item';
 
 interface Props {
   orders: Order[] | Promise<Order[]>;
+  orderNumberLabel?: string;
+  totalLabel?: string;
+  viewDetailsLabel?: string;
 }
 
 export function OrderList(props: Props) {
@@ -14,13 +17,19 @@ export function OrderList(props: Props) {
   );
 }
 
-function OrderListInner({ orders }: Props) {
+function OrderListInner({ orders, orderNumberLabel, totalLabel, viewDetailsLabel }: Props) {
   const resolved = orders instanceof Promise ? use(orders) : orders;
 
   return (
     <div className="@container">
       {resolved.map((order) => (
-        <OrderListItem key={order.id} order={order} />
+        <OrderListItem
+          key={order.id}
+          order={order}
+          orderNumberLabel={orderNumberLabel}
+          totalLabel={totalLabel}
+          viewDetailsLabel={viewDetailsLabel}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
### What/Why?

- Moves the margin from the subtitle onto the price label to keep margin consistency when there is no `subtitle` for a line item.
- Adds label props for the hardcoded text to provide the ability to localize messages.

### Testing

#### Without i18n:
![Screenshot 2025-01-03 at 15 30 23](https://github.com/user-attachments/assets/fd557c14-1d14-4a95-8532-3d5cf412c024)

#### With i18n:
![Screenshot 2025-01-03 at 15 30 10](https://github.com/user-attachments/assets/5c991461-84a6-4a50-a629-c3dc6d41f86d)
