### PR TITLE
fix: force default value for inputs in PDP

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -220,7 +220,7 @@ function FormField({
           onChange={(e) => handleChange(e.currentTarget.value)}
           onFocus={controls.focus}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? ''}
         />
       );
 
@@ -235,7 +235,7 @@ function FormField({
           onChange={(e) => handleChange(e.currentTarget.value)}
           onFocus={controls.focus}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? ''}
         />
       );
 
@@ -250,7 +250,7 @@ function FormField({
           onCheckedChange={(value) => handleChange(String(value))}
           onFocus={controls.focus}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? 'false'}
         />
       );
 
@@ -267,7 +267,7 @@ function FormField({
           onValueChange={handleChange}
           options={field.options}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? ''}
         />
       );
 
@@ -284,7 +284,7 @@ function FormField({
           onValueChange={handleChange}
           options={field.options}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? ''}
         />
       );
 
@@ -301,7 +301,7 @@ function FormField({
           onValueChange={handleChange}
           options={field.options}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? ''}
         />
       );
 
@@ -318,7 +318,7 @@ function FormField({
           onValueChange={handleChange}
           options={field.options}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? ''}
         />
       );
 
@@ -335,7 +335,7 @@ function FormField({
           onValueChange={handleChange}
           options={field.options}
           required={formField.required}
-          value={controls.value}
+          value={controls.value ?? ''}
         />
       );
   }


### PR DESCRIPTION
Even though we generate default values:

```ts
const defaultValue = fields.reduce<{
  [Key in keyof SchemaRawShape]?: z.infer<SchemaRawShape[Key]>;
}>(
  (acc, field) => ({
    ...acc,
    [field.name]: params[field.name] ?? field.defaultValue ?? '',
  }),
  { quantity: 1 },
);
```

Example of defaultValue object:

```
 {
  '108': '99',
  '109': '106',
  '130': '',
  '133': '137',
  '134': '140',
  '135': 'false',
  '136': '',
  '137': '',
  '138': '',
  '140': '',
  quantity: 1
}
```

For some reason, `useForm` sets empty strings as `undefined` for `defaultValue/initialValue`. Problem is we control all these fields in this form, so we can't change from `uncontrolled => controlled` without a warning.

Basically, it transforms to:

```
 {
  '108': '99',
  '109': '106',
  '130': undefined,
  '133': '137',
  '134': '140',
  '135': 'false',
  '136': undefined,
  '137': undefined,
  '138': undefined,
  '140': undefined,
  quantity: 1
}
```

With this change, we make sure the form field remains in a controlled state.

Why is `useForm` swapping `''` to `undefined`, this I couldn't figure out. It does make sense that it works this way since I assume many uses cases are for uncontrolled forms. Actual non empty string values do remain and work as expected.