### PR TITLE
fix: remove unecessary aria-role in radio groups

### DIFF
--- a/apps/web/vibes/soul/form/button-radio-group/index.tsx
+++ b/apps/web/vibes/soul/form/button-radio-group/index.tsx
@@ -30,7 +30,6 @@ export const ButtonRadioGroup = React.forwardRef<
         aria-labelledby={id}
         className="flex flex-wrap gap-2"
         ref={ref}
-        role="group"
       >
         {options.map((option) => (
           <RadioGroupPrimitive.Item

--- a/apps/web/vibes/soul/form/card-radio-group/index.tsx
+++ b/apps/web/vibes/soul/form/card-radio-group/index.tsx
@@ -27,13 +27,7 @@ export const CardRadioGroup = React.forwardRef<
   return (
     <div className={clsx('space-y-2', className)}>
       {label !== undefined && label !== '' && <Label id={id}>{label}</Label>}
-      <RadioGroupPrimitive.Root
-        {...rest}
-        aria-labelledby={id}
-        className="space-y-2"
-        ref={ref}
-        role="group"
-      >
+      <RadioGroupPrimitive.Root {...rest} aria-labelledby={id} className="space-y-2" ref={ref}>
         {options.map((option) => (
           <RadioGroupPrimitive.Item
             aria-label={option.label}

--- a/apps/web/vibes/soul/form/checkbox-group/index.tsx
+++ b/apps/web/vibes/soul/form/checkbox-group/index.tsx
@@ -37,7 +37,7 @@ export function CheckboxGroup({
   return (
     <div className={clsx('space-y-2', className)}>
       {label !== undefined && label !== '' && <Label id={id}>{label}</Label>}
-      <div aria-labelledby={id} className="space-y-2" role="group">
+      <div aria-labelledby={id} className="space-y-2">
         {options.map((option) => (
           <Checkbox
             checked={value.includes(option.value)}

--- a/apps/web/vibes/soul/form/radio-group/index.tsx
+++ b/apps/web/vibes/soul/form/radio-group/index.tsx
@@ -25,13 +25,7 @@ export const RadioGroup = React.forwardRef<
   return (
     <div className={clsx('space-y-2', className)}>
       {label !== undefined && label !== '' && <Label id={id}>{label}</Label>}
-      <RadioGroupPrimitive.Root
-        {...rest}
-        aria-labelledby={id}
-        className="space-y-2"
-        ref={ref}
-        role="group"
-      >
+      <RadioGroupPrimitive.Root {...rest} aria-labelledby={id} className="space-y-2" ref={ref}>
         {options.map((option, index) => (
           <RadioGroupItem
             error={errors != null && errors.length > 0}

--- a/apps/web/vibes/soul/form/swatch-radio-group/index.tsx
+++ b/apps/web/vibes/soul/form/swatch-radio-group/index.tsx
@@ -42,7 +42,6 @@ export const SwatchRadioGroup = React.forwardRef<
         aria-labelledby={id}
         className="flex flex-wrap gap-1"
         ref={ref}
-        role="group"
       >
         {options.map((option) => (
           <RadioGroupPrimitive.Item

--- a/apps/web/vibes/soul/form/toggle-group/index.tsx
+++ b/apps/web/vibes/soul/form/toggle-group/index.tsx
@@ -31,7 +31,6 @@ export const ToggleGroup = React.forwardRef<
         aria-labelledby={id}
         className="flex flex-wrap gap-2"
         ref={ref}
-        role="group"
       >
         {options.map((option) => (
           <ToggleGroupPrimitive.Item


### PR DESCRIPTION
Fixes an issue in Lighthouse with mismatched aria roles:

![image](https://github.com/user-attachments/assets/9da9b7ce-d17d-446b-bf87-fab0cbde4645)

Setting this is not required, any accessibility attribute is handled by radix, if any.
