### PR TITLE
feat(soul): refactor order detail page

### DIFF
--- a/apps/web/vibes/soul/examples/sections/order-details-section/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/order-details-section/electric.tsx
@@ -6,15 +6,13 @@ const products = await getProducts('Electric');
 
 const order = {
   id: '1',
-  title: 'Order #1',
   status: 'Delivered',
   statusColor: 'success' as const,
   date: '2021-01-01',
-  shipments: [
+  destinations: [
     {
       id: '1',
-      title: 'Shipment 1/2',
-      date: '2021-01-01',
+      title: 'Destination 1/2',
       address: {
         name: 'John Doe',
         street1: '1000 San Marcos Ave',
@@ -23,11 +21,15 @@ const order = {
         zipcode: '78702',
         country: 'United States',
       },
-      method: {
-        id: '1Z370170375602560',
-        name: 'UPS Ground',
-        status: 'Delivered on May 15, 2024',
-      },
+      shipments: [
+        {
+          tracking: {
+            number: '1Z370170375602560',
+          },
+          name: 'UPS Ground',
+          status: 'Delivered on May 15, 2024',
+        },
+      ],
       lineItems: products
         .filter(() => Math.random() > 0.5)
         .map(({ id, title, subtitle, image, href }) => ({
@@ -46,8 +48,7 @@ const order = {
     },
     {
       id: '2',
-      title: 'Shipment 2/2',
-      date: '2021-05-01',
+      title: 'Destination 2/2',
       address: {
         name: 'John Doe',
         street1: '1000 San Marcos Ave',
@@ -56,11 +57,15 @@ const order = {
         zipcode: '78702',
         country: 'United States',
       },
-      method: {
-        id: '1Z370170375612565',
-        name: 'UPS Ground',
-        status: 'Shipped on May 15, 2024',
-      },
+      shipments: [
+        {
+          tracking: {
+            number: '1Z370170375612565',
+          },
+          name: 'UPS Ground',
+          status: 'Shipped on May 15, 2024',
+        },
+      ],
       lineItems: products
         .filter(() => Math.random() > 0.5)
         .map(({ id, title, subtitle, image, href }) => ({

--- a/apps/web/vibes/soul/examples/sections/order-details-section/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/order-details-section/luxury.tsx
@@ -6,15 +6,13 @@ const products = await getProducts('Luxury');
 
 const order = {
   id: '1',
-  title: 'Order #1',
   status: 'Delivered',
   statusColor: 'success' as const,
   date: '2021-01-01',
-  shipments: [
+  destinations: [
     {
       id: '1',
-      title: 'Shipment 1/2',
-      date: '2021-01-01',
+      title: 'Destination 1/2',
       address: {
         name: 'John Doe',
         street1: '1000 San Marcos Ave',
@@ -23,11 +21,15 @@ const order = {
         zipcode: '78702',
         country: 'United States',
       },
-      method: {
-        id: '1Z370170375602560',
-        name: 'UPS Ground',
-        status: 'Delivered on May 15, 2024',
-      },
+      shipments: [
+        {
+          tracking: {
+            number: '1Z370170375602560',
+          },
+          name: 'UPS Ground',
+          status: 'Delivered on May 15, 2024',
+        },
+      ],
       lineItems: products
         .filter(() => Math.random() > 0.5)
         .map(({ id, title, subtitle, image, href }) => ({
@@ -46,8 +48,7 @@ const order = {
     },
     {
       id: '2',
-      title: 'Shipment 2/2',
-      date: '2021-05-01',
+      title: 'Destination 2/2',
       address: {
         name: 'John Doe',
         street1: '1000 San Marcos Ave',
@@ -56,11 +57,15 @@ const order = {
         zipcode: '78702',
         country: 'United States',
       },
-      method: {
-        id: '1Z370170375612565',
-        name: 'UPS Ground',
-        status: 'Shipped on May 15, 2024',
-      },
+      shipments: [
+        {
+          tracking: {
+            number: '1Z370170375612565',
+          },
+          name: 'UPS Ground',
+          status: 'Shipped on May 15, 2024',
+        },
+      ],
       lineItems: products
         .filter(() => Math.random() > 0.5)
         .map(({ id, title, subtitle, image, href }) => ({

--- a/apps/web/vibes/soul/examples/sections/order-details-section/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/order-details-section/warm.tsx
@@ -6,15 +6,13 @@ const products = await getProducts('Warm');
 
 const order = {
   id: '1',
-  title: 'Order #1',
   status: 'Delivered',
   statusColor: 'success' as const,
   date: '2021-01-01',
-  shipments: [
+  destinations: [
     {
       id: '1',
-      title: 'Shipment 1/2',
-      date: '2021-01-01',
+      title: 'Destination 1/2',
       address: {
         name: 'John Doe',
         street1: '1000 San Marcos Ave',
@@ -23,11 +21,15 @@ const order = {
         zipcode: '78702',
         country: 'United States',
       },
-      method: {
-        id: '1Z370170375602560',
-        name: 'UPS Ground',
-        status: 'Delivered on May 15, 2024',
-      },
+      shipments: [
+        {
+          tracking: {
+            number: '1Z370170375602560',
+          },
+          name: 'UPS Ground',
+          status: 'Delivered on May 15, 2024',
+        },
+      ],
       lineItems: products
         .filter(() => Math.random() > 0.5)
         .map(({ id, title, subtitle, image, href }) => ({
@@ -46,8 +48,7 @@ const order = {
     },
     {
       id: '2',
-      title: 'Shipment 2/2',
-      date: '2021-05-01',
+      title: 'Destination 2/2',
       address: {
         name: 'John Doe',
         street1: '1000 San Marcos Ave',
@@ -56,11 +57,15 @@ const order = {
         zipcode: '78702',
         country: 'United States',
       },
-      method: {
-        id: '1Z370170375612565',
-        name: 'UPS Ground',
-        status: 'Shipped on May 15, 2024',
-      },
+      shipments: [
+        {
+          tracking: {
+            number: '1Z370170375612565',
+          },
+          name: 'UPS Ground',
+          status: 'Shipped on May 15, 2024',
+        },
+      ],
       lineItems: products
         .filter(() => Math.random() > 0.5)
         .map(({ id, title, subtitle, image, href }) => ({


### PR DESCRIPTION
## What/Why?

### Updates `shipments` to `destinations`

This change is due to how ecommerce orders are actually handled. For example, when you place an order you can ship X items to one address, and ship Y items to another. This is also called consignments, but to make it more friendly to the end user, I opted for the name `destinations` instead.

### Multiple shipments per destination.

In ecomm, each destination can have multiple shipments. This all depends on how the order is fulfilled by each merchant. Some products need to be sent in multiple boxes (e.g. furniture) or send in partial shipments (e.g. as products arrive at the warehouse). I refactored the schema to handle multiple shipments under each destination.

### Tracking information link vs. text

Added the ability to handle links in the tracking information field. With this came renaming `id` to `number` as it might cause some confusion for developers that they might need an entity id instead.

### Internationalization

Elevated some hard coded strings into props to provide better internationalization to strings.

## Testing
![Screenshot 2025-01-08 at 14 45 44](https://github.com/user-attachments/assets/8306b3fd-21b9-4d78-9826-3b88a01d32e9)
