### PR TITLE
feat(soul): add layout CSS to Select component

### DIFF
--- a/apps/web/vibes/soul/form/select/index.tsx
+++ b/apps/web/vibes/soul/form/select/index.tsx
@@ -43,7 +43,7 @@ export function Select({
   const id = React.useId();
 
   return (
-    <div className={className}>
+    <div className={clsx('w-full space-y-2', className)}>
       {label !== undefined && label !== '' && (
         <Label className={clsx(hideLabel && 'sr-only', 'mb-2')} htmlFor={id}>
           {label}


### PR DESCRIPTION
## What/why

Adds some layout CSS to prevent the select from shrinking in side-by-side rows:
![Screenshot 2025-01-09 at 11 18 36](https://github.com/user-attachments/assets/f2d5523e-11a2-4c37-aa75-4b32324b938f)



## Testing
Tested the pages that use this component to ensure there aren't any regressions.

### PDP
Before:
![Screenshot 2025-01-09 at 11 12 22](https://github.com/user-attachments/assets/717a0b9c-e93c-47b6-bf57-e8d61c072a4d)
After:
![Screenshot 2025-01-09 at 11 12 26](https://github.com/user-attachments/assets/6778f948-74d5-4ebd-a3ec-20fb6e96edab)

### PLP
Before:
![Screenshot 2025-01-09 at 11 14 14](https://github.com/user-attachments/assets/acc8bb84-11e9-4d6b-a716-7d202e978f39)

After:
![Screenshot 2025-01-09 at 11 13 07](https://github.com/user-attachments/assets/5bb9cb73-d7ee-4f34-8c11-2c0950e2f966)
