### PR TITLE
fix: sticky sidebar layout overflow

### DIFF
--- a/apps/web/vibes/soul/sections/sticky-sidebar-layout/index.tsx
+++ b/apps/web/vibes/soul/sections/sticky-sidebar-layout/index.tsx
@@ -47,7 +47,7 @@ export function StickySidebarLayout({
       >
         <div
           className={clsx(
-            'shrink-0',
+            'min-w-0',
             sidebarPosition === 'after' ? 'order-2' : 'order-1',
             {
               '1/3': '@4xl:w-1/3',
@@ -63,6 +63,7 @@ export function StickySidebarLayout({
         </div>
         <div
           className={clsx(
+            'min-w-0',
             sidebarPosition === 'after' ? 'order-1' : 'order-2',
             {
               '1/3': '@4xl:w-2/3',


### PR DESCRIPTION
When using an Image inside of a StickySidebarLayout a min width was being set preventing it from shrinking in a flex layout. This PR fixes this by setting a min width of 0 on the columns in the StickySidebarLayout component.