### PR TITLE
feat: add currency dropdown to Navigation

### DIFF
--- a/apps/web/vibes/soul/primitives/navigation/index.tsx
+++ b/apps/web/vibes/soul/primitives/navigation/index.tsx
@@ -47,6 +47,11 @@ interface Locale {
   label: string;
 }
 
+interface Currency {
+  id: string;
+  label: string;
+}
+
 type Action<State, Payload> = (
   state: Awaited<State>,
   payload: Awaited<Payload>,
@@ -71,6 +76,7 @@ export type SearchResult =
     };
 
 type LocaleAction = Action<SubmissionResult | null, FormData>;
+type CurrencyAction = Action<SubmissionResult | null, FormData>;
 type SearchAction<S extends SearchResult> = Action<
   {
     searchResults: S[] | null;
@@ -92,6 +98,9 @@ interface Props<S extends SearchResult> {
   locales?: Locale[];
   activeLocaleId?: string;
   localeAction?: LocaleAction;
+  currencies?: Currency[];
+  activeCurrencyId?: Streamable<string | undefined>;
+  currencyAction?: CurrencyAction;
   logo?: Streamable<string | { src: string; alt: string } | null>;
   logoWidth?: number;
   logoHeight?: number;
@@ -264,6 +273,9 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
     activeLocaleId,
     localeAction,
     locales,
+    currencies,
+    activeCurrencyId: streamableActiveCurrencyId,
+    currencyAction,
     searchHref,
     searchParamName = 'query',
     searchAction,
@@ -560,6 +572,29 @@ export const Navigation = forwardRef(function Navigation<S extends SearchResult>
               locales={locales as [Locale, Locale, ...Locale[]]}
             />
           ) : null}
+
+          {/* Currency Dropdown */}
+          {currencies && currencies.length > 1 && currencyAction ? (
+            <Stream
+              fallback={
+                <CurrencyForm
+                  action={currencyAction}
+                  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                  currencies={currencies as [Currency, ...Currency[]]}
+                />
+              }
+              value={streamableActiveCurrencyId}
+            >
+              {(activeCurrencyId) => (
+                <CurrencyForm
+                  action={currencyAction}
+                  activeCurrencyId={activeCurrencyId}
+                  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+                  currencies={currencies as [Currency, ...Currency[]]}
+                />
+              )}
+            </Stream>
+          ) : null}
         </div>
       </div>
 
@@ -854,6 +889,65 @@ function LocaleForm({
               }}
             >
               {label}
+            </DropdownMenu.Item>
+          ))}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+function CurrencyForm({
+  action,
+  currencies,
+  activeCurrencyId,
+}: {
+  activeCurrencyId?: string;
+  action: CurrencyAction;
+  currencies: [Currency, ...Currency[]];
+}) {
+  const [lastResult, formAction] = useActionState(action, null);
+  const activeCurrency = currencies.find((currency) => currency.id === activeCurrencyId);
+
+  useEffect(() => {
+    if (lastResult?.error) console.log(lastResult.error);
+  }, [lastResult?.error]);
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        className={clsx('flex items-center gap-1 text-xs uppercase', navButtonClassName)}
+      >
+        {activeCurrency?.label ?? currencies[0].label}
+        <ChevronDown size={16} strokeWidth={1.5} />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          className="z-50 max-h-80 overflow-y-scroll rounded-xl bg-[var(--nav-locale-background,hsl(var(--background)))] p-2 shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 @4xl:w-32 @4xl:rounded-2xl @4xl:p-2"
+          sideOffset={16}
+        >
+          {currencies.map((currency) => (
+            <DropdownMenu.Item
+              className={clsx(
+                'cursor-default rounded-lg bg-[var(--nav-locale-link-background,transparent)] px-2.5 py-2 font-[family-name:var(--nav-locale-link-font-family,var(--font-family-body))] text-sm font-medium text-[var(--nav-locale-link-text,hsl(var(--contrast-400)))] outline-none ring-[var(--nav-focus,hsl(var(--primary)))] transition-colors hover:bg-[var(--nav-locale-link-background-hover,hsl(var(--contrast-100)))] hover:text-[var(--nav-locale-link-text-hover,hsl(var(--foreground)))]',
+                {
+                  'text-[var(--nav-locale-link-text-selected,hsl(var(--foreground)))]':
+                    currency.id === activeCurrencyId,
+                },
+              )}
+              key={currency.id}
+              onSelect={() => {
+                // eslint-disable-next-line @typescript-eslint/require-await
+                startTransition(async () => {
+                  const formData = new FormData();
+
+                  formData.append('id', currency.id);
+                  formAction(formData);
+                });
+              }}
+            >
+              {currency.label}
             </DropdownMenu.Item>
           ))}
         </DropdownMenu.Content>

--- a/apps/web/vibes/soul/primitives/navigation/index.tsx
+++ b/apps/web/vibes/soul/primitives/navigation/index.tsx
@@ -28,6 +28,7 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { Logo } from '@/vibes/soul/primitives/logo';
 import { Price } from '@/vibes/soul/primitives/price-label';
 import { ProductCard } from '@/vibes/soul/primitives/product-card';
+import { toast } from '@/vibes/soul/primitives/toaster';
 
 interface Link {
   label: string;
@@ -850,9 +851,17 @@ function LocaleForm({
   const [lastResult, formAction] = useActionState(action, null);
   const activeLocale = locales.find((locale) => locale.id === activeLocaleId);
 
+  const [form] = useForm({
+    lastResult,
+  });
+
   useEffect(() => {
-    if (lastResult?.error) console.log(lastResult.error);
-  }, [lastResult?.error]);
+    if (form.errors) {
+      form.errors.forEach((error) => {
+        toast.error(error);
+      });
+    }
+  }, [form.errors]);
 
   return (
     <DropdownMenu.Root>
@@ -909,9 +918,17 @@ function CurrencyForm({
   const [lastResult, formAction] = useActionState(action, null);
   const activeCurrency = currencies.find((currency) => currency.id === activeCurrencyId);
 
+  const [form] = useForm({
+    lastResult,
+  });
+
   useEffect(() => {
-    if (lastResult?.error) console.log(lastResult.error);
-  }, [lastResult?.error]);
+    if (form.errors) {
+      form.errors.forEach((error) => {
+        toast.error(error);
+      });
+    }
+  }, [form.errors]);
 
   return (
     <DropdownMenu.Root>


### PR DESCRIPTION
Sucessor to #472

Adds the currency dropdown to Navigation, that triggers a server action in a form, like locales.

![image](https://github.com/user-attachments/assets/12db7050-d67a-4e4b-b90f-89cfce3178d8)


