### PR TITLE
feat: add Chip primitive

### DIFF
--- a/apps/web/vibes/soul/docs/chip.mdx
+++ b/apps/web/vibes/soul/docs/chip.mdx
@@ -1,0 +1,5 @@
+---
+title: Chip
+preview: chip-example
+previewSize: xs
+---

--- a/apps/web/vibes/soul/examples.ts
+++ b/apps/web/vibes/soul/examples.ts
@@ -209,6 +209,13 @@ export const examples = [
     component: lazy(() => import('./examples/primitives/checkbox')),
   },
   {
+    name: 'chip-example',
+    dependencies: [],
+    registryDependencies: ['chip'],
+    files: ['examples/primitives/chip/index.tsx'],
+    component: lazy(() => import('./examples/primitives/chip')),
+  },
+  {
     name: 'checkout-example',
     dependencies: [],
     registryDependencies: ['checkout'],

--- a/apps/web/vibes/soul/examples/primitives/chip/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/chip/index.tsx
@@ -1,0 +1,9 @@
+import { Chip } from '@/vibes/soul/primitives/chip';
+
+export default function Preview() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <Chip>Chip</Chip>
+    </div>
+  );
+}

--- a/apps/web/vibes/soul/navigation.ts
+++ b/apps/web/vibes/soul/navigation.ts
@@ -88,6 +88,7 @@ export const navigation = [
         component: 'card-carousel',
       },
       { title: 'Checkbox', slug: 'checkbox', file: 'docs/checkbox.mdx', component: 'checkbox' },
+      { title: 'Chip', slug: 'chip', file: 'docs/chip.mdx', component: 'chip' },
       { title: 'Countdown', slug: 'countdown', file: 'docs/countdown.mdx', component: 'countdown' },
       { title: 'Counter', slug: 'counter', file: 'docs/counter.mdx', component: 'counter' },
       {

--- a/apps/web/vibes/soul/primitives/chip/index.tsx
+++ b/apps/web/vibes/soul/primitives/chip/index.tsx
@@ -1,0 +1,32 @@
+import { X } from 'lucide-react';
+
+interface Props {
+  buttonName?: string;
+  buttonValue?: string;
+  children?: React.ReactNode;
+  removeLabel?: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export const Chip = function Chip({
+  buttonName,
+  buttonValue,
+  children,
+  removeLabel = 'Remove',
+  onClick,
+}: Props) {
+  return (
+    <span className="flex h-9 items-center gap-1.5 rounded-lg bg-contrast-100 px-3 py-2 text-sm font-semibold leading-5 text-foreground">
+      {children}
+      <button
+        className="flex h-5 w-5 items-center justify-center rounded-full hover:bg-contrast-200 focus:outline-none focus:ring-1 focus:ring-foreground"
+        name={buttonName}
+        onClick={onClick}
+        title={removeLabel}
+        value={buttonValue}
+      >
+        <X size={12} />
+      </button>
+    </span>
+  );
+};

--- a/apps/web/vibes/soul/primitives/chip/index.tsx
+++ b/apps/web/vibes/soul/primitives/chip/index.tsx
@@ -16,7 +16,7 @@ export const Chip = function Chip({
   onClick,
 }: Props) {
   return (
-    <span className="flex h-9 items-center gap-1.5 rounded-lg bg-contrast-100 px-3 py-2 text-sm font-semibold leading-5 text-foreground">
+    <span className="flex h-9 items-center gap-1.5 rounded-lg bg-contrast-100 py-2 pe-2 ps-3 text-sm font-semibold leading-5 text-foreground">
       {children}
       <button
         className="flex h-5 w-5 items-center justify-center rounded-full hover:bg-contrast-200 focus:outline-none focus:ring-1 focus:ring-foreground"


### PR DESCRIPTION
Adds `Chip` primitive that will be used in `Cart` section.

![Screenshot 2025-02-10 at 2 06 49 PM](https://github.com/user-attachments/assets/2daffe69-68d3-4667-b127-b7b83a72db7f)

![Screenshot 2025-02-10 at 2 06 52 PM](https://github.com/user-attachments/assets/78c2e943-5c6b-4065-af69-2bd22c81b992)

![Screenshot 2025-02-10 at 2 06 56 PM](https://github.com/user-attachments/assets/0d8bddbc-6ad0-4e83-86d1-74311e4232d9)
