### PR TITLE
fix: rename Accordions to Accordion

### DIFF
--- a/apps/web/vibes/soul/docs/accordion.mdx
+++ b/apps/web/vibes/soul/docs/accordion.mdx
@@ -1,7 +1,7 @@
 ---
-title: Accordions
+title: Accordion
 description: Accordions allow users to expand and collapse content sections.
-preview: accordions-example
+preview: accordion-example
 previewSize: sm
 features:
   - Full keyboard navigation

--- a/apps/web/vibes/soul/examples.ts
+++ b/apps/web/vibes/soul/examples.ts
@@ -6,11 +6,11 @@ import { Components } from '@/vibes/schema';
 
 export const examples = [
   {
-    name: 'accordions-example',
+    name: 'accordion-example',
     dependencies: [],
-    registryDependencies: ['accordions'],
-    files: ['examples/primitives/accordions/index.tsx'],
-    component: lazy(() => import('./examples/primitives/accordions')),
+    registryDependencies: ['accordion'],
+    files: ['examples/primitives/accordion/index.tsx'],
+    component: lazy(() => import('./examples/primitives/accordion')),
   },
   {
     name: 'sticky-sidebar-layout-example',

--- a/apps/web/vibes/soul/examples/primitives/accordion/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/accordion/index.tsx
@@ -1,7 +1,7 @@
-import { Accordion, Accordions } from '@/vibes/soul/primitives/accordions';
+import { Accordion, AccordionItem } from '@/vibes/soul/primitives/accordion';
 
 export default function Preview() {
-  const accordions = [
+  const accordionItems = [
     {
       title: 'What is your return policy?',
       content:
@@ -27,28 +27,28 @@ export default function Preview() {
   return (
     <div className="space-y-4">
       <div className="py-8">
-        <Accordions
+        <Accordion
           className="m-auto w-1/2 max-w-screen-lg items-start justify-center p-10"
           type="multiple"
         >
-          {accordions.map(({ title, content }, index) => (
-            <Accordion key={index} title={title} value={index.toString()}>
+          {accordionItems.map(({ title, content }, index) => (
+            <AccordionItem key={index} title={title} value={index.toString()}>
               {content}
-            </Accordion>
+            </AccordionItem>
           ))}
-        </Accordions>
+        </Accordion>
       </div>
       <div className="bg-foreground py-8">
-        <Accordions
+        <Accordion
           className="m-auto w-1/2 max-w-screen-lg items-start justify-center p-10"
           type="multiple"
         >
-          {accordions.map(({ title, content }, index) => (
-            <Accordion colorScheme="dark" key={index} title={title} value={index.toString()}>
+          {accordionItems.map(({ title, content }, index) => (
+            <AccordionItem colorScheme="dark" key={index} title={title} value={index.toString()}>
               {content}
-            </Accordion>
+            </AccordionItem>
           ))}
-        </Accordions>
+        </Accordion>
       </div>
     </div>
   );

--- a/apps/web/vibes/soul/navigation.ts
+++ b/apps/web/vibes/soul/navigation.ts
@@ -20,10 +20,10 @@ export const navigation = [
     title: 'Components',
     pages: [
       {
-        title: 'Accordions',
-        slug: 'accordions',
-        file: 'docs/accordions.mdx',
-        component: 'accordions',
+        title: 'Accordion',
+        slug: 'accordion',
+        file: 'docs/accordion.mdx',
+        component: 'accordion',
       },
       {
         title: 'Alert',

--- a/apps/web/vibes/soul/primitives.ts
+++ b/apps/web/vibes/soul/primitives.ts
@@ -2,10 +2,10 @@ import { Components } from '@/vibes/schema';
 
 export const primitives = [
   {
-    name: 'accordions',
+    name: 'accordion',
     dependencies: ['clsx', '@radix-ui/react-accordion'],
     registryDependencies: [],
-    files: ['primitives/accordions/index.tsx'],
+    files: ['primitives/accordion/index.tsx'],
   },
   {
     name: 'alert',
@@ -19,7 +19,6 @@ export const primitives = [
     registryDependencies: [],
     files: ['primitives/animated-link/index.tsx'],
   },
-
   {
     name: 'badge',
     dependencies: ['clsx'],

--- a/apps/web/vibes/soul/primitives/accordion/index.tsx
+++ b/apps/web/vibes/soul/primitives/accordion/index.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import * as AccordionsPrimitive from '@radix-ui/react-accordion';
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { clsx } from 'clsx';
 import { ComponentPropsWithoutRef, useEffect, useState } from 'react';
 
-export interface AccordionProps extends ComponentPropsWithoutRef<typeof AccordionsPrimitive.Item> {
+export interface AccordionProps extends ComponentPropsWithoutRef<typeof AccordionPrimitive.Item> {
   colorScheme?: 'light' | 'dark';
 }
 
@@ -32,7 +32,7 @@ export interface AccordionProps extends ComponentPropsWithoutRef<typeof Accordio
  * }
  * ```
  */
-function Accordion({
+function AccordionItem({
   title,
   children,
   colorScheme = 'light',
@@ -46,7 +46,7 @@ function Accordion({
   }, []);
 
   return (
-    <AccordionsPrimitive.Item
+    <AccordionPrimitive.Item
       {...props}
       className={clsx(
         'focus:outline-2 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-[var(--accordion-focus,hsl(var(--primary)))] has-[:focus-visible]:ring-offset-4',
@@ -57,8 +57,8 @@ function Accordion({
         className,
       )}
     >
-      <AccordionsPrimitive.Header>
-        <AccordionsPrimitive.Trigger className="group flex w-full cursor-pointer items-start gap-8 border-none py-3 text-start focus:outline-none @md:py-4">
+      <AccordionPrimitive.Header>
+        <AccordionPrimitive.Trigger className="group flex w-full cursor-pointer items-start gap-8 border-none py-3 text-start focus:outline-none @md:py-4">
           <div
             className={clsx(
               'flex-1 select-none font-[family-name:var(--accordion-title-font-family,var(--font-family-mono))] text-sm font-normal uppercase transition-colors duration-300 ease-out',
@@ -80,9 +80,9 @@ function Accordion({
               }[colorScheme],
             )}
           />
-        </AccordionsPrimitive.Trigger>
-      </AccordionsPrimitive.Header>
-      <AccordionsPrimitive.Content
+        </AccordionPrimitive.Trigger>
+      </AccordionPrimitive.Header>
+      <AccordionPrimitive.Content
         className={clsx(
           'overflow-hidden',
           // We need to delay the animation until the component is mounted to avoid the animation
@@ -101,8 +101,8 @@ function Accordion({
         >
           {children}
         </div>
-      </AccordionsPrimitive.Content>
-    </AccordionsPrimitive.Item>
+      </AccordionPrimitive.Content>
+    </AccordionPrimitive.Item>
   );
 }
 
@@ -142,6 +142,6 @@ function AnimatedChevron({
   );
 }
 
-const Accordions = AccordionsPrimitive.Root;
+const Accordion = AccordionPrimitive.Root;
 
-export { Accordions, Accordion };
+export { Accordion, AccordionItem };

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -1,5 +1,5 @@
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
-import { Accordion, Accordions } from '@/vibes/soul/primitives/accordions';
+import { Accordion, AccordionItem } from '@/vibes/soul/primitives/accordion';
 import { Breadcrumb, Breadcrumbs } from '@/vibes/soul/primitives/breadcrumbs';
 import { Price, PriceLabel } from '@/vibes/soul/primitives/price-label';
 import { Rating } from '@/vibes/soul/primitives/rating';
@@ -143,13 +143,17 @@ export function ProductDetail<F extends Field>({
                   <Stream fallback={<ProductAccordionsSkeleton />} value={product.accordions}>
                     {(accordions) =>
                       accordions && (
-                        <Accordions className="border-t border-contrast-100 pt-4" type="multiple">
+                        <Accordion className="border-t border-contrast-100 pt-4" type="multiple">
                           {accordions.map((accordion, index) => (
-                            <Accordion key={index} title={accordion.title} value={index.toString()}>
+                            <AccordionItem
+                              key={index}
+                              title={accordion.title}
+                              value={index.toString()}
+                            >
                               {accordion.content}
-                            </Accordion>
+                            </AccordionItem>
                           ))}
-                        </Accordions>
+                        </Accordion>
                       )
                     }
                   </Stream>

--- a/apps/web/vibes/soul/sections/products-list-section/filters-panel.tsx
+++ b/apps/web/vibes/soul/sections/products-list-section/filters-panel.tsx
@@ -13,7 +13,7 @@ import { Checkbox } from '@/vibes/soul/form/checkbox';
 import { RangeInput } from '@/vibes/soul/form/range-input';
 import { ToggleGroup } from '@/vibes/soul/form/toggle-group';
 import { Streamable, useStreamable } from '@/vibes/soul/lib/streamable';
-import { Accordion, Accordions } from '@/vibes/soul/primitives/accordions';
+import { Accordion, AccordionItem } from '@/vibes/soul/primitives/accordion';
 import { Button } from '@/vibes/soul/primitives/button';
 import { CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { Rating } from '@/vibes/soul/primitives/rating';
@@ -150,7 +150,7 @@ export function FiltersPanelInner({
           </ul>
         </div>
       ))}
-      <Accordions
+      <Accordion
         onValueChange={(items) =>
           setAccordionItems((prevItems) =>
             prevItems.map((prevItem) => ({
@@ -168,7 +168,7 @@ export function FiltersPanelInner({
           switch (filter.type) {
             case 'toggle-group':
               return (
-                <Accordion
+                <AccordionItem
                   key={key}
                   title={`${filter.label}${getParamCountLabel(optimisticParams, filter.paramName)}`}
                   value={value}
@@ -192,12 +192,12 @@ export function FiltersPanelInner({
                     type="multiple"
                     value={optimisticParams[filter.paramName] ?? []}
                   />
-                </Accordion>
+                </AccordionItem>
               );
 
             case 'range':
               return (
-                <Accordion key={key} title={filter.label} value={value}>
+                <AccordionItem key={key} title={filter.label} value={value}>
                   <RangeInput
                     applyLabel={rangeFilterApplyLabel}
                     disabled={filter.disabled}
@@ -230,12 +230,12 @@ export function FiltersPanelInner({
                       max: optimisticParams[filter.maxParamName] ?? null,
                     }}
                   />
-                </Accordion>
+                </AccordionItem>
               );
 
             case 'rating':
               return (
-                <Accordion key={key} title={filter.label} value={value}>
+                <AccordionItem key={key} title={filter.label} value={value}>
                   <div className="space-y-3">
                     {[5, 4, 3, 2, 1].map((rating) => (
                       <Checkbox
@@ -266,14 +266,14 @@ export function FiltersPanelInner({
                       />
                     ))}
                   </div>
-                </Accordion>
+                </AccordionItem>
               );
 
             default:
               return null;
           }
         })}
-      </Accordions>
+      </Accordion>
 
       <Button
         onClick={() => {


### PR DESCRIPTION
## What / Why
- Renames `Accordions` to `Accordion`
- Renames `Accordion` to `AccordionItem`

## Testing

https://github.com/user-attachments/assets/6ff4bde9-52bc-47e6-b16a-33650b58e238

