### PR TITLE
audit: badge component

### DIFF
--- a/apps/web/vibes/soul/examples/primitives/badge/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/badge/index.tsx
@@ -3,8 +3,8 @@ import { Badge } from '@/vibes/soul/primitives/badge';
 export default function Preview() {
   return (
     <div className="flex h-screen items-center justify-center gap-4">
-      <Badge variant="pill">Pill</Badge>
-      <Badge variant="rounded">Rounded</Badge>
+      <Badge shape="pill">Pill</Badge>
+      <Badge shape="rounded">Rounded</Badge>
     </div>
   );
 }

--- a/apps/web/vibes/soul/primitives/badge/index.tsx
+++ b/apps/web/vibes/soul/primitives/badge/index.tsx
@@ -1,30 +1,49 @@
 import { clsx } from 'clsx';
-import { ReactNode } from 'react';
 
-interface Props {
-  children: ReactNode;
-  variant?: 'pill' | 'rounded';
-  color?: 'primary' | 'accent' | 'warning' | 'danger' | 'success' | 'info';
+export interface BadgeProps {
+  children: string;
+  shape?: 'pill' | 'rounded';
+  variant?: 'primary' | 'warning' | 'error' | 'success' | 'info';
   className?: string;
 }
 
-export function Badge({ children, variant = 'rounded', className, color = 'primary' }: Props) {
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --badge-primary-background: color-mix(in oklab, hsl(var(--primary)), white 75%);
+ *   --badge-accent-background: hsl(var(--accent));
+ *   --badge-success-background: color-mix(in oklab, hsl(var(--success)), white 75%);
+ *   --badge-warning-background: color-mix(in oklab, hsl(var(--warning)), white 75%);
+ *   --badge-error-background: color-mix(in oklab, hsl(var(--error)), white 75%);
+ *   --badge-info-background: color-mix(in oklab, hsl(var(--background)), black 5%);
+ *   --badge-text: hsl(var(--foreground));
+ *   --badge-font-family: var(--font-family-mono);
+ * }
+ * ```
+ */
+export function Badge({ children, shape = 'rounded', className, variant = 'primary' }: BadgeProps) {
   return (
     <span
       className={clsx(
-        'bg-primary-highlight px-2 py-0.5 font-mono text-xs uppercase tracking-tighter text-foreground',
+        'px-2 py-0.5 font-[family-name:var(--badge-font-family,var(--font-family-mono))] text-xs uppercase tracking-tighter text-[var(--badge-text,hsl(var(--foreground)))]',
         {
           pill: 'rounded-full',
           rounded: 'rounded',
-        }[variant],
+        }[shape],
         {
-          primary: 'bg-primary-highlight',
-          accent: 'bg-accent-highlight',
-          warning: 'bg-warning-highlight',
-          danger: 'bg-danger-highlight',
-          success: 'bg-success-highlight',
-          info: 'bg-info-highlight',
-        }[color],
+          primary:
+            'bg-[var(--badge-primary-background,color-mix(in_oklab,_hsl(var(--primary)),_white_75%))]',
+          warning:
+            'bg-[var(--badge-warning-background,color-mix(in_oklab,_hsl(var(--warning)),_white_75%))]',
+          error:
+            'bg-[var(--badge-error-background,color-mix(in_oklab,_hsl(var(--error)),_white_75%))]',
+          success:
+            'bg-[var(--badge-success-background,color-mix(in_oklab,_hsl(var(--success)),_white_75%))]',
+          info: 'bg-[var(--badge-info-background,color-mix(in_oklab,_hsl(var(--background)),_black_5%))]',
+        }[variant],
         className,
       )}
     >

--- a/apps/web/vibes/soul/primitives/product-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/index.tsx
@@ -110,7 +110,7 @@ export function ProductCard({
             </div>
           )}
           {badge != null && badge !== '' && (
-            <Badge className="absolute left-3 top-3" variant="rounded">
+            <Badge className="absolute left-3 top-3" shape="rounded">
               {badge}
             </Badge>
           )}

--- a/apps/web/vibes/soul/sections/order-details-section/index.tsx
+++ b/apps/web/vibes/soul/sections/order-details-section/index.tsx
@@ -64,7 +64,7 @@ interface Destination {
 export interface Order {
   id: string;
   status: string;
-  statusColor?: 'success' | 'warning' | 'danger' | 'info';
+  statusColor?: 'success' | 'warning' | 'error' | 'info';
   date: string;
   destinations: Destination[];
   summary: Summary;
@@ -99,7 +99,7 @@ export function OrderDetailsSection({
         <div className="space-y-1">
           <div className="flex items-center gap-3">
             <h1 className="text-4xl">{title}</h1>
-            <Badge color={order.statusColor}>{order.status}</Badge>
+            <Badge variant={order.statusColor}>{order.status}</Badge>
           </div>
           <p>{order.date}</p>
         </div>


### PR DESCRIPTION
## What/Why
- Renames `variant` to `shape` and `color` to `variant` to match the existing naming pattern
- Changes `children` to be of type `string` 
- Exports interface
- Updates existing examples  

## Testing

https://github.com/user-attachments/assets/264105b9-6ac7-4cd6-98b0-c84e7edfeedd



