### PR TITLE
feat: add coupon code form to Cart

### DIFF
--- a/apps/web/vibes/soul/examples/pages/cart/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/electric.tsx
@@ -3,7 +3,11 @@ import { locales } from '@/vibes/soul/data/locales';
 import { action } from '@/vibes/soul/examples/primitives/inline-email-form/actions';
 import { localeAction } from '@/vibes/soul/examples/primitives/navigation/actions';
 import { logo, navigationLinks } from '@/vibes/soul/examples/primitives/navigation/electric';
-import { checkoutAction, lineItemAction } from '@/vibes/soul/examples/sections/cart/actions';
+import {
+  checkoutAction,
+  couponCodeAction,
+  lineItemAction,
+} from '@/vibes/soul/examples/sections/cart/actions';
 import { copyright, footerLinks } from '@/vibes/soul/examples/sections/footer/electric';
 import { Banner } from '@/vibes/soul/primitives/banner';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
@@ -80,6 +84,7 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
+          couponCodeAction: couponCodeAction,
         }}
         checkoutAction={checkoutAction}
         lineItemAction={lineItemAction}

--- a/apps/web/vibes/soul/examples/pages/cart/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/electric.tsx
@@ -84,9 +84,9 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
-          couponCodeAction,
         }}
         checkoutAction={checkoutAction}
+        couponCode={{ action: couponCodeAction }}
         lineItemAction={lineItemAction}
       />
 

--- a/apps/web/vibes/soul/examples/pages/cart/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/electric.tsx
@@ -84,7 +84,7 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
-          couponCodeAction: couponCodeAction,
+          couponCodeAction,
         }}
         checkoutAction={checkoutAction}
         lineItemAction={lineItemAction}

--- a/apps/web/vibes/soul/examples/pages/cart/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/luxury.tsx
@@ -3,7 +3,11 @@ import { locales } from '@/vibes/soul/data/locales';
 import { action } from '@/vibes/soul/examples/primitives/inline-email-form/actions';
 import { localeAction } from '@/vibes/soul/examples/primitives/navigation/actions';
 import { logo, navigationLinks } from '@/vibes/soul/examples/primitives/navigation/electric';
-import { checkoutAction, lineItemAction } from '@/vibes/soul/examples/sections/cart/actions';
+import {
+  checkoutAction,
+  couponCodeAction,
+  lineItemAction,
+} from '@/vibes/soul/examples/sections/cart/actions';
 import { copyright, footerLinks } from '@/vibes/soul/examples/sections/footer/electric';
 import { Banner } from '@/vibes/soul/primitives/banner';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
@@ -80,6 +84,7 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
+          couponCodeAction: couponCodeAction,
         }}
         checkoutAction={checkoutAction}
         lineItemAction={lineItemAction}

--- a/apps/web/vibes/soul/examples/pages/cart/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/luxury.tsx
@@ -84,9 +84,9 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
-          couponCodeAction,
         }}
         checkoutAction={checkoutAction}
+        couponCode={{ action: couponCodeAction }}
         lineItemAction={lineItemAction}
       />
 

--- a/apps/web/vibes/soul/examples/pages/cart/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/luxury.tsx
@@ -84,7 +84,7 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
-          couponCodeAction: couponCodeAction,
+          couponCodeAction,
         }}
         checkoutAction={checkoutAction}
         lineItemAction={lineItemAction}

--- a/apps/web/vibes/soul/examples/pages/cart/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/warm.tsx
@@ -83,7 +83,7 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
-          couponCodeAction: couponCodeAction,
+          couponCodeAction,
         }}
         checkoutAction={checkoutAction}
         lineItemAction={lineItemAction}

--- a/apps/web/vibes/soul/examples/pages/cart/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/warm.tsx
@@ -83,9 +83,9 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
-          couponCodeAction,
         }}
         checkoutAction={checkoutAction}
+        couponCode={{ action: couponCodeAction }}
         lineItemAction={lineItemAction}
       />
 

--- a/apps/web/vibes/soul/examples/pages/cart/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/cart/warm.tsx
@@ -3,7 +3,11 @@ import { locales } from '@/vibes/soul/data/locales';
 import { action } from '@/vibes/soul/examples/primitives/inline-email-form/actions';
 import { localeAction } from '@/vibes/soul/examples/primitives/navigation/actions';
 import { logo, navigationLinks } from '@/vibes/soul/examples/primitives/navigation/electric';
-import { checkoutAction, lineItemAction } from '@/vibes/soul/examples/sections/cart/actions';
+import {
+  checkoutAction,
+  couponCodeAction,
+  lineItemAction,
+} from '@/vibes/soul/examples/sections/cart/actions';
 import { copyright, footerLinks } from '@/vibes/soul/examples/sections/footer/electric';
 import { Banner } from '@/vibes/soul/primitives/banner';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
@@ -79,6 +83,7 @@ export default async function Preview() {
             { label: 'Tax', value: 'TBD' },
           ],
           total: '127.60',
+          couponCodeAction: couponCodeAction,
         }}
         checkoutAction={checkoutAction}
         lineItemAction={lineItemAction}

--- a/apps/web/vibes/soul/examples/sections/cart/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/cart/actions.ts
@@ -1,7 +1,11 @@
 import { SubmissionResult } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
 
-import { cartLineItemActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
+import { CouponCodeFormState } from '@/vibes/soul/sections/cart/coupon-code-form';
+import {
+  cartLineItemActionFormDataSchema,
+  couponCodeActionFormDataSchema,
+} from '@/vibes/soul/sections/cart/schema';
 
 interface CartLineItem {
   id: string;
@@ -86,4 +90,42 @@ export async function checkoutAction(
   // return redirect('/checkout')
 
   return prevState;
+}
+
+export async function couponCodeAction(
+  prevState: Awaited<CouponCodeFormState>,
+  formData: FormData,
+): Promise<CouponCodeFormState> {
+  'use server';
+
+  const submission = parseWithZod(formData, { schema: couponCodeActionFormDataSchema });
+
+  if (submission.status !== 'success') {
+    return {
+      ...prevState,
+      lastResult: submission.reply({ formErrors: ['This code has expired or is invalid!'] }),
+    };
+  }
+
+  // Simulate a network request
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  switch (submission.value.intent) {
+    case 'apply': {
+      const couponCode = submission.value.couponCode;
+
+      return {
+        couponCodes: [...prevState.couponCodes, couponCode],
+        lastResult: submission.reply({ resetForm: true }),
+      };
+    }
+    case 'delete': {
+      const couponCode = submission.value.couponCode;
+
+      return {
+        couponCodes: prevState.couponCodes.filter((code) => code !== couponCode),
+        lastResult: submission.reply({ resetForm: true }),
+      };
+    }
+  }
 }

--- a/apps/web/vibes/soul/examples/sections/cart/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/cart/actions.ts
@@ -103,7 +103,7 @@ export async function couponCodeAction(
   if (submission.status !== 'success') {
     return {
       ...prevState,
-      lastResult: submission.reply({ formErrors: ['This code has expired or is invalid!'] }),
+      lastResult: submission.reply(),
     };
   }
 

--- a/apps/web/vibes/soul/examples/sections/cart/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/cart/actions.ts
@@ -98,7 +98,7 @@ export async function couponCodeAction(
 ): Promise<CouponCodeFormState> {
   'use server';
 
-  const submission = parseWithZod(formData, { schema: couponCodeActionFormDataSchema });
+  const submission = parseWithZod(formData, { schema: couponCodeActionFormDataSchema({}) });
 
   if (submission.status !== 'success') {
     return {

--- a/apps/web/vibes/soul/examples/sections/cart/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/cart/actions.ts
@@ -115,13 +115,15 @@ export async function couponCodeAction(
       const couponCode = submission.value.couponCode;
 
       return {
-        couponCodes: [couponCode],
+        couponCodes: [...prevState.couponCodes, couponCode],
         lastResult: submission.reply({ resetForm: true }),
       };
     }
     case 'delete': {
       return {
-        couponCodes: [],
+        couponCodes: [...prevState.couponCodes].filter(
+          (code) => code !== submission.value.couponCode,
+        ),
         lastResult: submission.reply({ resetForm: true }),
       };
     }

--- a/apps/web/vibes/soul/examples/sections/cart/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/cart/actions.ts
@@ -115,15 +115,13 @@ export async function couponCodeAction(
       const couponCode = submission.value.couponCode;
 
       return {
-        couponCodes: [...prevState.couponCodes, couponCode],
+        couponCodes: [couponCode],
         lastResult: submission.reply({ resetForm: true }),
       };
     }
     case 'delete': {
-      const couponCode = submission.value.couponCode;
-
       return {
-        couponCodes: prevState.couponCodes.filter((code) => code !== couponCode),
+        couponCodes: [],
         lastResult: submission.reply({ resetForm: true }),
       };
     }

--- a/apps/web/vibes/soul/examples/sections/cart/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/electric.tsx
@@ -161,7 +161,7 @@ async function getCart() {
     ),
   );
 
-  return { ...cart, couponCodeAction: couponCodeAction };
+  return { ...cart, couponCodeAction };
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/electric.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { Cart, CartLineItem } from '@/vibes/soul/sections/cart';
 import { cartLineItemActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
 
+import { couponCodeAction } from './actions';
+
 export default async function Preview() {
   return (
     <div className="p-4">
@@ -158,7 +160,8 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-  return cart;
+
+  return { ...cart, couponCodeAction: couponCodeAction };
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/electric.tsx
@@ -21,6 +21,7 @@ export default async function Preview() {
       <Cart
         cart={getCartWithDelay()}
         checkoutAction={checkoutAction}
+        couponCode={{ action: couponCodeAction }}
         key={await getCartId()}
         lineItemAction={lineItemAction}
       />
@@ -161,7 +162,7 @@ async function getCart() {
     ),
   );
 
-  return { ...cart, couponCodeAction };
+  return cart;
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/electric.tsx
@@ -161,7 +161,6 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-
   return cart;
 }
 

--- a/apps/web/vibes/soul/examples/sections/cart/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/luxury.tsx
@@ -21,6 +21,7 @@ export default async function Preview() {
       <Cart
         cart={getCartWithDelay()}
         checkoutAction={checkoutAction}
+        couponCode={{ action: couponCodeAction }}
         key={await getCartId()}
         lineItemAction={lineItemAction}
       />
@@ -160,7 +161,7 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-  return { ...cart, couponCodeAction };
+  return cart;
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/luxury.tsx
@@ -160,7 +160,7 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-  return { ...cart, couponCodeAction: couponCodeAction };
+  return { ...cart, couponCodeAction };
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/luxury.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { Cart, CartLineItem } from '@/vibes/soul/sections/cart';
 import { cartLineItemActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
 
+import { couponCodeAction } from './actions';
+
 export default async function Preview() {
   return (
     <div className="p-4">
@@ -158,7 +160,7 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-  return cart;
+  return { ...cart, couponCodeAction: couponCodeAction };
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/warm.tsx
@@ -21,6 +21,7 @@ export default async function Preview() {
       <Cart
         cart={getCartWithDelay()}
         checkoutAction={checkoutAction}
+        couponCode={{ action: couponCodeAction }}
         key={await getCartId()}
         lineItemAction={lineItemAction}
       />
@@ -160,7 +161,7 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-  return { ...cart, couponCodeAction };
+  return cart;
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/warm.tsx
@@ -160,7 +160,7 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-  return { ...cart, couponCodeAction: couponCodeAction };
+  return { ...cart, couponCodeAction };
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/examples/sections/cart/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/cart/warm.tsx
@@ -8,6 +8,8 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { Cart, CartLineItem } from '@/vibes/soul/sections/cart';
 import { cartLineItemActionFormDataSchema } from '@/vibes/soul/sections/cart/schema';
 
+import { couponCodeAction } from './actions';
+
 export default async function Preview() {
   return (
     <div className="p-4">
@@ -158,7 +160,7 @@ async function getCart() {
         JSON.stringify(generateCartFromLineItems(defaultLineItems)),
     ),
   );
-  return cart;
+  return { ...cart, couponCodeAction: couponCodeAction };
 }
 
 async function setCart(cart: Cart<CartLineItem>) {

--- a/apps/web/vibes/soul/form/input/index.tsx
+++ b/apps/web/vibes/soul/form/input/index.tsx
@@ -27,19 +27,19 @@ import { Label } from '@/vibes/soul/form/label';
  */
 export const Input = React.forwardRef<
   React.ComponentRef<'input'>,
-  Omit<React.ComponentPropsWithoutRef<'input'>, 'id'> & {
+  React.ComponentPropsWithoutRef<'input'> & {
     prepend?: React.ReactNode;
     label?: string;
     errors?: string[];
     colorScheme?: 'light' | 'dark';
   }
->(({ prepend, label, className, required, errors, colorScheme = 'light', ...rest }, ref) => {
-  const id = React.useId();
+>(({ prepend, label, className, required, errors, colorScheme = 'light', id, ...rest }, ref) => {
+  const generatedId = React.useId();
 
   return (
     <div className={clsx('w-full space-y-2', className)}>
       {label != null && label !== '' && (
-        <Label colorScheme={colorScheme} htmlFor={id}>
+        <Label colorScheme={colorScheme} htmlFor={id ?? generatedId}>
           {label}
         </Label>
       )}
@@ -69,7 +69,7 @@ export const Input = React.forwardRef<
             }[colorScheme],
             { 'py-2.5 pe-4 ps-12': prepend },
           )}
-          id={id}
+          id={id ?? generatedId}
           ref={ref}
         />
       </div>

--- a/apps/web/vibes/soul/primitives/chip/index.tsx
+++ b/apps/web/vibes/soul/primitives/chip/index.tsx
@@ -1,16 +1,16 @@
 import { X } from 'lucide-react';
 
 interface Props {
-  buttonName?: string;
-  buttonValue?: string;
+  name?: string;
+  value?: string;
   children?: React.ReactNode;
   removeLabel?: string;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const Chip = function Chip({
-  buttonName,
-  buttonValue,
+  name,
+  value,
   children,
   removeLabel = 'Remove',
   onClick,
@@ -20,10 +20,10 @@ export const Chip = function Chip({
       {children}
       <button
         className="flex h-5 w-5 items-center justify-center rounded-full hover:bg-contrast-200 focus:outline-none focus:ring-1 focus:ring-foreground"
-        name={buttonName}
+        name={name}
         onClick={onClick}
         title={removeLabel}
-        value={buttonValue}
+        value={value}
       >
         <X size={12} />
       </button>

--- a/apps/web/vibes/soul/sections/cart/client.tsx
+++ b/apps/web/vibes/soul/sections/cart/client.tsx
@@ -43,13 +43,16 @@ export interface Cart<LineItem extends CartLineItem> {
   summaryItems: CartSummaryItem[];
   total: string;
   totalLabel?: string;
+}
+
+interface CouponCode {
+  action?: Action<CouponCodeFormState, FormData>;
   couponCodes?: string[];
-  couponCodeAction?: Action<CouponCodeFormState, FormData>;
-  couponCodeCtaLabel?: string;
-  couponCodeDisabled?: boolean;
-  couponCodeLabel?: string;
-  couponCodePlaceholder?: string;
-  couponCodeRemoveLabel?: string;
+  ctaLabel?: string;
+  disabled?: boolean;
+  label?: string;
+  placeholder?: string;
+  removeLabel?: string;
 }
 
 export interface Props<LineItem extends CartLineItem> {
@@ -63,6 +66,7 @@ export interface Props<LineItem extends CartLineItem> {
   decrementLineItemLabel?: string;
   incrementLineItemLabel?: string;
   cart: Cart<LineItem>;
+  couponCode?: CouponCode;
 }
 
 const defaultEmptyState = {
@@ -74,6 +78,7 @@ const defaultEmptyState = {
 export function CartClient<LineItem extends CartLineItem>({
   title,
   cart,
+  couponCode,
   decrementLineItemLabel,
   incrementLineItemLabel,
   deleteLineItemLabel,
@@ -157,15 +162,15 @@ export function CartClient<LineItem extends CartLineItem>({
               ))}
             </div>
 
-            {cart.couponCodeAction && (
+            {couponCode && (
               <CouponCodeForm
-                action={cart.couponCodeAction}
-                couponCodes={cart.couponCodes}
-                ctaLabel={cart.couponCodeCtaLabel}
-                disabled={cart.couponCodeDisabled}
-                label={cart.couponCodeLabel}
-                placeholder={cart.couponCodePlaceholder}
-                removeLabel={cart.couponCodeRemoveLabel}
+                action={couponCode.action}
+                couponCodes={couponCode.couponCodes}
+                ctaLabel={couponCode.ctaLabel}
+                disabled={couponCode.disabled}
+                label={couponCode.label}
+                placeholder={couponCode.placeholder}
+                removeLabel={couponCode.removeLabel}
               />
             )}
 

--- a/apps/web/vibes/soul/sections/cart/client.tsx
+++ b/apps/web/vibes/soul/sections/cart/client.tsx
@@ -46,7 +46,7 @@ export interface Cart<LineItem extends CartLineItem> {
 }
 
 interface CouponCode {
-  action?: Action<CouponCodeFormState, FormData>;
+  action: Action<CouponCodeFormState, FormData>;
   couponCodes?: string[];
   ctaLabel?: string;
   disabled?: boolean;

--- a/apps/web/vibes/soul/sections/cart/client.tsx
+++ b/apps/web/vibes/soul/sections/cart/client.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/vibes/soul/primitives/button';
 import { toast } from '@/vibes/soul/primitives/toaster';
 import { StickySidebarLayout } from '@/vibes/soul/sections/sticky-sidebar-layout';
 
+import { CouponCodeForm, CouponCodeFormState } from './coupon-code-form';
 import { cartLineItemActionFormDataSchema } from './schema';
 
 import { CartEmptyState } from '.';
@@ -42,6 +43,13 @@ export interface Cart<LineItem extends CartLineItem> {
   summaryItems: CartSummaryItem[];
   total: string;
   totalLabel?: string;
+  couponCodes?: string[];
+  couponCodeAction?: Action<CouponCodeFormState, FormData>;
+  couponCodeCtaLabel?: string;
+  couponCodeDisabled?: boolean;
+  couponCodeLabel?: string;
+  couponCodePlaceholder?: string;
+  couponCodeRemoveLabel?: string;
 }
 
 export interface Props<LineItem extends CartLineItem> {
@@ -148,6 +156,18 @@ export function CartClient<LineItem extends CartLineItem>({
                 </div>
               ))}
             </div>
+
+            {cart.couponCodeAction && (
+              <CouponCodeForm
+                action={cart.couponCodeAction}
+                couponCodes={cart.couponCodes}
+                ctaLabel={cart.couponCodeCtaLabel}
+                disabled={cart.couponCodeDisabled}
+                label={cart.couponCodeLabel}
+                placeholder={cart.couponCodePlaceholder}
+                removeLabel={cart.couponCodeRemoveLabel}
+              />
+            )}
 
             <div className="flex justify-between border-t border-contrast-100 py-6 text-xl font-bold">
               <dt>{cart.totalLabel ?? 'Total'}</dt>

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form.tsx
@@ -76,12 +76,7 @@ export function CouponCodeForm({
         {actionStateCouponCodes.map((couponCode) => (
           <form action={formAction} key={couponCode}>
             <input name="couponCode" type="hidden" value={couponCode} />
-            <Chip
-              buttonName="intent"
-              buttonValue="delete"
-              key={couponCode}
-              removeLabel={removeLabel}
-            >
+            <Chip key={couponCode} name="intent" removeLabel={removeLabel} value="delete">
               {couponCode.toUpperCase()}
             </Chip>
           </form>

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { getFormProps, getInputProps, SubmissionResult, useForm } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+import { useActionState } from 'react';
+import { useFormStatus } from 'react-dom';
+
+import { FieldError } from '@/vibes/soul/form/field-error';
+import { Input } from '@/vibes/soul/form/input';
+import { Button } from '@/vibes/soul/primitives/button';
+import { Chip } from '@/vibes/soul/primitives/chip';
+
+import { couponCodeActionFormDataSchema } from './schema';
+
+type Action<State, Payload> = (state: Awaited<State>, payload: Payload) => State | Promise<State>;
+
+export interface CouponCodeFormState {
+  couponCodes: string[];
+  lastResult: SubmissionResult | null;
+}
+
+interface Props {
+  action: Action<CouponCodeFormState, FormData>;
+  couponCodes?: string[];
+  ctaLabel?: string;
+  disabled?: boolean;
+  label?: string;
+  placeholder?: string;
+  removeLabel?: string;
+}
+
+export function CouponCodeForm({
+  action,
+  couponCodes,
+  ctaLabel = 'Apply',
+  disabled = false,
+  label = 'Promo code',
+  placeholder,
+  removeLabel = 'Remove promo code',
+}: Props) {
+  const [{ couponCodes: actionStateCouponCodes, lastResult }, formAction] = useActionState(action, {
+    couponCodes: couponCodes ?? [],
+    lastResult: null,
+  });
+
+  const [form, fields] = useForm({
+    lastResult,
+    shouldValidate: 'onBlur',
+    shouldRevalidate: 'onInput',
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: couponCodeActionFormDataSchema });
+    },
+  });
+
+  return (
+    <div className="border-t border-contrast-100 py-6">
+      <form {...getFormProps(form)} action={formAction} className="space-y-2">
+        <label htmlFor={fields.couponCode.id}>{label}</label>
+        <div className="flex gap-1.5">
+          <Input
+            {...getInputProps(fields.couponCode, {
+              required: true,
+              type: 'text',
+            })}
+            disabled={disabled}
+            errors={fields.couponCode.errors}
+            id={fields.couponCode.id}
+            key={fields.couponCode.id}
+            placeholder={placeholder}
+          />
+          <SubmitButton disabled={disabled}>{ctaLabel}</SubmitButton>
+        </div>
+        {form.errors?.map((error, index) => <FieldError key={index}>{error}</FieldError>)}
+      </form>
+      <div className="flex flex-wrap gap-1.5 pt-3">
+        {actionStateCouponCodes.map((couponCode) => (
+          <form action={formAction} key={couponCode}>
+            <input name="couponCode" type="hidden" value={couponCode} />
+            <Chip
+              buttonName="intent"
+              buttonValue="delete"
+              key={couponCode}
+              removeLabel={removeLabel}
+            >
+              {couponCode.toUpperCase()}
+            </Chip>
+          </form>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SubmitButton({ disabled, ...props }: React.ComponentPropsWithoutRef<typeof Button>) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button
+      {...props}
+      disabled={disabled ?? pending}
+      loading={pending}
+      name="intent"
+      size="small"
+      type="submit"
+      value="apply"
+      variant="secondary"
+    />
+  );
+}

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form.tsx
@@ -53,7 +53,7 @@ export function CouponCodeForm({
   });
 
   return (
-    <div className="border-t border-contrast-100 py-6">
+    <div className="border-t border-contrast-100 pb-5 pt-4">
       <form {...getFormProps(form)} action={formAction} className="space-y-2">
         <label htmlFor={fields.couponCode.id}>{label}</label>
         <div className="flex gap-1.5">

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/coupon-chip.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/coupon-chip.tsx
@@ -20,7 +20,9 @@ export function CouponChip({
 }: Props) {
   const [form, fields] = useForm({
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: couponCodeActionFormDataSchema });
+      return parseWithZod(formData, {
+        schema: couponCodeActionFormDataSchema({}),
+      });
     },
     onSubmit(event, { formData }) {
       event.preventDefault();

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/coupon-chip.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/coupon-chip.tsx
@@ -1,0 +1,45 @@
+import { getFormProps, getInputProps, useForm } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+
+import { Chip } from '@/vibes/soul/primitives/chip';
+
+import { couponCodeActionFormDataSchema } from '../schema';
+
+interface Props {
+  action: (payload: FormData) => void;
+  onSubmit: (formData: FormData) => void;
+  couponCode: string;
+  removeLabel?: string;
+}
+
+export function CouponChip({
+  couponCode,
+  removeLabel = 'Remove promo code',
+  onSubmit,
+  action,
+}: Props) {
+  const [form, fields] = useForm({
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: couponCodeActionFormDataSchema });
+    },
+    onSubmit(event, { formData }) {
+      event.preventDefault();
+
+      onSubmit(formData);
+    },
+  });
+
+  return (
+    <form {...getFormProps(form)} action={action}>
+      <input
+        {...getInputProps(fields.couponCode, {
+          type: 'hidden',
+        })}
+        value={couponCode}
+      />
+      <Chip name="intent" removeLabel={removeLabel} value="delete">
+        {couponCode.toUpperCase()}
+      </Chip>
+    </form>
+  );
+}

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -57,7 +57,9 @@ export function CouponCodeForm({
 
       switch (submission.value.intent) {
         case 'delete': {
-          return [];
+          const couponCode = submission.value.couponCode;
+
+          return prevState.filter((code) => code !== couponCode);
         }
 
         default:

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -59,13 +59,11 @@ export function CouponCodeForm({
         case 'apply': {
           const { couponCode } = submission.value;
 
-          return [...prevState, couponCode];
+          return [couponCode];
         }
 
         case 'delete': {
-          const { couponCode } = submission.value;
-
-          return prevState.filter((code) => code !== couponCode);
+          return [];
         }
 
         default:

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -92,7 +92,7 @@ export function CouponCodeForm({
   });
 
   return (
-    <div className="space-y-3 border-t border-contrast-100 pb-5 pt-4">
+    <div className="space-y-2 border-t border-contrast-100 pb-5 pt-4">
       <form {...getFormProps(form)} action={formAction} className="space-y-2">
         <label htmlFor={fields.couponCode.id}>{label}</label>
         <div className="flex gap-1.5">
@@ -110,22 +110,24 @@ export function CouponCodeForm({
           <SubmitButton disabled={disabled}>{ctaLabel}</SubmitButton>
         </div>
       </form>
-      <div className="flex flex-wrap gap-1.5">
-        {optimisticCouponCodes.map((couponCode) => (
-          <CouponChip
-            action={formAction}
-            couponCode={couponCode}
-            key={couponCode}
-            onSubmit={(formData) => {
-              startTransition(() => {
-                formAction(formData);
-                setOptimisticCouponCodes(formData);
-              });
-            }}
-            removeLabel={removeLabel}
-          />
-        ))}
-      </div>
+      {optimisticCouponCodes.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {optimisticCouponCodes.map((couponCode) => (
+            <CouponChip
+              action={formAction}
+              couponCode={couponCode}
+              key={couponCode}
+              onSubmit={(formData) => {
+                startTransition(() => {
+                  formAction(formData);
+                  setOptimisticCouponCodes(formData);
+                });
+              }}
+              removeLabel={removeLabel}
+            />
+          ))}
+        </div>
+      )}
       {form.errors?.map((error, index) => <FieldError key={index}>{error}</FieldError>)}
     </div>
   );

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -28,6 +28,7 @@ interface Props {
   label?: string;
   placeholder?: string;
   removeLabel?: string;
+  requiredErrorMessage?: string;
 }
 
 export function CouponCodeForm({
@@ -38,6 +39,7 @@ export function CouponCodeForm({
   label = 'Promo code',
   placeholder,
   removeLabel,
+  requiredErrorMessage,
 }: Props) {
   const [state, formAction] = useActionState(action, {
     couponCodes: couponCodes ?? [],
@@ -47,7 +49,9 @@ export function CouponCodeForm({
   const [optimisticCouponCodes, setOptimisticCouponCodes] = useOptimistic<string[], FormData>(
     state.couponCodes,
     (prevState, formData) => {
-      const submission = parseWithZod(formData, { schema: couponCodeActionFormDataSchema });
+      const submission = parseWithZod(formData, {
+        schema: couponCodeActionFormDataSchema({ required_error: requiredErrorMessage }),
+      });
 
       if (submission.status !== 'success') return prevState;
 
@@ -75,7 +79,9 @@ export function CouponCodeForm({
     shouldValidate: 'onBlur',
     shouldRevalidate: 'onInput',
     onValidate({ formData }) {
-      return parseWithZod(formData, { schema: couponCodeActionFormDataSchema });
+      return parseWithZod(formData, {
+        schema: couponCodeActionFormDataSchema({ required_error: requiredErrorMessage }),
+      });
     },
     onSubmit(event, { formData }) {
       event.preventDefault();

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -56,12 +56,6 @@ export function CouponCodeForm({
       if (submission.status !== 'success') return prevState;
 
       switch (submission.value.intent) {
-        case 'apply': {
-          const { couponCode } = submission.value;
-
-          return [couponCode];
-        }
-
         case 'delete': {
           return [];
         }

--- a/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
+++ b/apps/web/vibes/soul/sections/cart/coupon-code-form/index.tsx
@@ -133,6 +133,7 @@ function SubmitButton({ disabled, ...props }: React.ComponentPropsWithoutRef<typ
   return (
     <Button
       {...props}
+      className="shrink-0"
       disabled={disabled ?? pending}
       loading={pending}
       name="intent"

--- a/apps/web/vibes/soul/sections/cart/schema.ts
+++ b/apps/web/vibes/soul/sections/cart/schema.ts
@@ -14,3 +14,14 @@ export const cartLineItemActionFormDataSchema = z.discriminatedUnion('intent', [
     id: z.string(),
   }),
 ]);
+
+export const couponCodeActionFormDataSchema = z.discriminatedUnion('intent', [
+  z.object({
+    couponCode: z.string(),
+    intent: z.literal('apply'),
+  }),
+  z.object({
+    couponCode: z.string(),
+    intent: z.literal('delete'),
+  }),
+]);

--- a/apps/web/vibes/soul/sections/cart/schema.ts
+++ b/apps/web/vibes/soul/sections/cart/schema.ts
@@ -17,11 +17,11 @@ export const cartLineItemActionFormDataSchema = z.discriminatedUnion('intent', [
 
 export const couponCodeActionFormDataSchema = z.discriminatedUnion('intent', [
   z.object({
-    couponCode: z.string(),
     intent: z.literal('apply'),
+    couponCode: z.string(),
   }),
   z.object({
-    couponCode: z.string(),
     intent: z.literal('delete'),
+    couponCode: z.string(),
   }),
 ]);

--- a/apps/web/vibes/soul/sections/cart/schema.ts
+++ b/apps/web/vibes/soul/sections/cart/schema.ts
@@ -15,13 +15,18 @@ export const cartLineItemActionFormDataSchema = z.discriminatedUnion('intent', [
   }),
 ]);
 
-export const couponCodeActionFormDataSchema = z.discriminatedUnion('intent', [
-  z.object({
-    intent: z.literal('apply'),
-    couponCode: z.string({ required_error: 'Please enter a valid promo code' }),
-  }),
-  z.object({
-    intent: z.literal('delete'),
-    couponCode: z.string(),
-  }),
-]);
+export const couponCodeActionFormDataSchema = ({
+  required_error = 'Please enter a valid promo code',
+}: {
+  required_error?: string;
+}) =>
+  z.discriminatedUnion('intent', [
+    z.object({
+      intent: z.literal('apply'),
+      couponCode: z.string({ required_error }),
+    }),
+    z.object({
+      intent: z.literal('delete'),
+      couponCode: z.string(),
+    }),
+  ]);

--- a/apps/web/vibes/soul/sections/cart/schema.ts
+++ b/apps/web/vibes/soul/sections/cart/schema.ts
@@ -18,7 +18,7 @@ export const cartLineItemActionFormDataSchema = z.discriminatedUnion('intent', [
 export const couponCodeActionFormDataSchema = z.discriminatedUnion('intent', [
   z.object({
     intent: z.literal('apply'),
-    couponCode: z.string(),
+    couponCode: z.string({ required_error: 'Please enter a valid promo code' }),
   }),
   z.object({
     intent: z.literal('delete'),


### PR DESCRIPTION
Adds coupon code form to Cart section.

In coupon code you can:
1. Apply a coupon code
2. Remove existing coupon codes

Exposed props to Cart section to pass to the form. Updated examples to include coupon code form.

## Demo
https://github.com/user-attachments/assets/4d5e020a-7696-4977-94ce-da2d166a45cc

## Error state
![Screenshot 2025-02-12 at 2 24 26 PM](https://github.com/user-attachments/assets/93d7ca78-75ad-4a97-8068-a6cea445acc7)


