### PR TITLE
audit: card

### DIFF
--- a/apps/web/vibes/soul/examples/primitives/card/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/card/index.tsx
@@ -6,19 +6,17 @@ export default function Preview() {
       <div className="bg-background p-8 @container">
         <div className="m-auto flex max-w-screen-md flex-col items-center gap-8 @md:flex-row">
           <Card
-            className="w-full"
             href="#"
             image={{ src: 'https://rstr.in/monogram/vibes/RopDQNbjTc_', alt: 'Low Maintenance' }}
             title="Low Maintenance"
           />
-          <Card className="w-full" href="#" title="Partial shade" />
+          <Card href="#" title="Partial shade" />
         </div>
       </div>
       <div className="bg-foreground p-8 @container">
         <div className="m-auto flex max-w-screen-md flex-col items-center gap-8 @md:flex-row">
           <Card
             aspectRatio="1:1"
-            className="w-full"
             href="#"
             iconColorScheme="dark"
             image={{ src: 'https://rstr.in/monogram/vibes/RopDQNbjTc_', alt: 'Low Maintenance' }}
@@ -27,7 +25,6 @@ export default function Preview() {
           />
           <Card
             aspectRatio="1:1"
-            className="w-full"
             href="#"
             iconColorScheme="dark"
             textColorScheme="dark"

--- a/apps/web/vibes/soul/primitives/blog-post-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/blog-post-card/index.tsx
@@ -52,7 +52,12 @@ export function BlogPostCard({
   className,
 }: BlogPostCardProps) {
   return (
-    <article className={clsx('group relative w-full max-w-md @container', className)}>
+    <article
+      className={clsx(
+        'group relative w-full max-w-md font-[family-name:var(--blog-post-card-font-family,var(--font-family-body))] @container',
+        className,
+      )}
+    >
       <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl bg-[var(--blog-post-card-image-background,hsl(var(--contrast-100)))]">
         {image != null ? (
           <Image
@@ -91,8 +96,7 @@ export function BlogPostCard({
       </div>
       <Link
         className={clsx(
-          'absolute inset-0 rounded-b-lg rounded-t-2xl font-[family-name:var(--blog-post-card-font-family,var(--font-family-body))] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--blog-post-card-focus,hsl(var(--primary)))] focus-visible:ring-offset-4',
-          className,
+          'absolute inset-0 rounded-b-lg rounded-t-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--blog-post-card-focus,hsl(var(--primary)))] focus-visible:ring-offset-4',
         )}
         href={href}
       >

--- a/apps/web/vibes/soul/primitives/card/index.tsx
+++ b/apps/web/vibes/soul/primitives/card/index.tsx
@@ -22,13 +22,13 @@ export interface CardProps {
  * ```css
  * :root {
  *   --card-focus: hsl(var(--primary));
- *   --card-border-radius: 1rem;
  *   --card-light-text: hsl(var(--foreground));
  *   --card-light-icon: hsl(var(--foreground));
  *   --card-light-background: hsl(var(--contrast-100));
  *   --card-dark-text: hsl(var(--background));
  *   --card-dark-icon: hsl(var(--background));
  *   --card-dark-background: hsl(var(--contrast-500));
+ *   --card-font-family: var(--font-family-body);
  * }
  * ```
  */
@@ -42,12 +42,11 @@ export function Card({
   aspectRatio = '5:6',
 }: CardProps) {
   return (
-    <Link
+    <article
       className={clsx(
-        'group relative flex min-w-0 cursor-pointer flex-col gap-2 rounded-[var(--card-border-radius,1rem)] @container focus:outline-0 focus-visible:outline-0',
+        'group relative flex w-full min-w-0 max-w-md cursor-pointer flex-col gap-2 rounded-2xl font-[family-name:var(--card-font-family,var(--font-family-body))] @container',
         className,
       )}
-      href={href}
     >
       <ArrowUpRight
         className={clsx(
@@ -112,7 +111,19 @@ export function Card({
       >
         {title}
       </span>
-    </Link>
+      <Link
+        className={clsx(
+          'absolute inset-0 rounded-b-lg rounded-t-2xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--blog-post-card-focus,hsl(var(--primary)))] focus-visible:ring-offset-4',
+          {
+            light: 'ring-offset-[var(--card-light-offset,hsl(var(--background)))]',
+            dark: 'ring-offset-[var(--card-dark-offset,hsl(var(--foreground)))]',
+          }[textColorScheme],
+        )}
+        href={href}
+      >
+        <span className="sr-only">View product</span>
+      </Link>
+    </article>
   );
 }
 
@@ -127,7 +138,7 @@ export function CardSkeleton({
     <div className={clsx('@container', className)}>
       <Skeleton.Box
         className={clsx(
-          'rounded-[var(--card-border-radius,1rem)]',
+          'rounded-2xl',
           {
             '5:6': 'aspect-[5/6]',
             '3:4': 'aspect-[3/4]',
@@ -136,7 +147,7 @@ export function CardSkeleton({
         )}
       />
       <div className="mt-3">
-        <Skeleton.Text className="rounded text-lg" characterCount={10} />
+        <Skeleton.Text characterCount={10} className="rounded text-lg" />
       </div>
     </div>
   );

--- a/apps/web/vibes/soul/primitives/product-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/index.tsx
@@ -185,9 +185,9 @@ export function ProductCardSkeleton({
       />
       <div className="mt-2 flex flex-col items-start gap-x-4 gap-y-3 px-1 @xs:mt-3 @2xl:flex-row">
         <div className="w-full text-base">
-          <Skeleton.Text className="rounded" characterCount={10} />
-          <Skeleton.Text className="rounded" characterCount={8} />
-          <Skeleton.Text className="rounded" characterCount={6} />
+          <Skeleton.Text characterCount={10} className="rounded" />
+          <Skeleton.Text characterCount={8} className="rounded" />
+          <Skeleton.Text characterCount={6} className="rounded" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What/Why
- Removed `w-full` from `Card` component–I think we should avoid doing this, especially if we want the `className` prop to be used sparingly for things like adjusting `margin`
- Made card an `article` element
- Set the `Link` component to be absolutely positioned
- Added focus styles to `Link`
- Added offset color styles for light vs dark variants
- Added some CSS variables
- Removed rounded border from CSS variables–I'd like to stick to just colors and fonts for this first release
- Fixed a quick error in `BlogPostCard` where I was passing in `className` in the `Link` component still
- Fixed random ESLint rules about prop order