### PR TITLE
audit: cursor pagination

### DIFF
--- a/apps/web/vibes/soul/examples/primitives/cursor-pagination/index.tsx
+++ b/apps/web/vibes/soul/examples/primitives/cursor-pagination/index.tsx
@@ -3,9 +3,9 @@ import { CursorPagination } from '@/vibes/soul/primitives/cursor-pagination';
 export default function Page() {
   return (
     <>
-      <CursorPagination info={{ endCursor: '2' }} />
+      <CursorPagination info={{ startCursor: null, endCursor: '2' }} />
       <CursorPagination info={{ startCursor: '1', endCursor: '2' }} />
-      <CursorPagination info={{ startCursor: '1' }} />
+      <CursorPagination info={{ startCursor: '1', endCursor: null }} />
     </>
   );
 }


### PR DESCRIPTION
## What/Why
- Updated `CursorPagination` to use `Stream`
- Updated `CursorPaginationSkeleton` to use `Skeleton` primitive
- Added CSS vars
- Changed `startCursor` and `endCursor` from optional since the default value would've been set to `null` anyway. Also, it's easier to understand what's going on in the example when `null` is passed in IMO.