### PR TITLE
audit: not found

### DIFF
--- a/apps/web/vibes/soul/docs/not-found.mdx
+++ b/apps/web/vibes/soul/docs/not-found.mdx
@@ -3,3 +3,45 @@ title: Not Found
 preview: not-found-example
 previewSize: sm
 ---
+
+## Usage
+
+{/* prettier-ignore-start */}
+
+<CodeBlock lang="ts">{`
+import { NotFound } from '@/vibes/soul/sections/not-found';
+
+function Usage() {
+
+    return (
+        <NotFound/>
+    );
+}
+
+
+`}
+</CodeBlock>
+
+{/* prettier-ignore-end */}
+
+## API Reference
+
+### NotFoundProps
+
+| Prop       | Type     | Default |
+| ---------- | -------- | ------- |
+| `title`    | `string` |         |
+| `subtitle` | `string` |         |
+
+### CSS Variables
+
+This component supports various CSS variables for theming. Here's a comprehensive list.
+
+```css
+:root {
+  --not-found-font-family: var(--font-family-body);
+  --not-found-title-font-family: var(--font-family-heading);
+  --not-found-title: hsl(var(--foreground));
+  --not-found-subtitle: hsl(var(--contrast-500));
+}
+```

--- a/apps/web/vibes/soul/docs/not-found.mdx
+++ b/apps/web/vibes/soul/docs/not-found.mdx
@@ -1,0 +1,5 @@
+---
+title: Not Found
+preview: not-found-example
+previewSize: sm
+---

--- a/apps/web/vibes/soul/examples.ts
+++ b/apps/web/vibes/soul/examples.ts
@@ -702,6 +702,13 @@ export const examples = [
     component: lazy(() => import('./examples/primitives/navigation/luxury')),
   },
   {
+    name: 'not-found-example',
+    dependencies: [],
+    registryDependencies: ['section-layout'],
+    files: ['examples/sections/not-found/index.tsx'],
+    component: lazy(() => import('./examples/sections/not-found')),
+  },
+  {
     name: 'number-input-example',
     dependencies: [],
     registryDependencies: ['number-input'],

--- a/apps/web/vibes/soul/examples/sections/not-found/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/not-found/index.tsx
@@ -1,0 +1,5 @@
+import { NotFound } from '@/vibes/soul/sections/not-found';
+
+export default function Preview() {
+  return <NotFound />;
+}

--- a/apps/web/vibes/soul/navigation.ts
+++ b/apps/web/vibes/soul/navigation.ts
@@ -289,6 +289,12 @@ const sectionPages: [Page, ...Page[]] = [
     component: 'inline-email-form',
   },
   {
+    title: 'Not Found',
+    slug: 'not-found',
+    file: 'docs/not-found.mdx',
+    component: 'not-found',
+  },
+  {
     title: 'Order Details Section',
     slug: 'order-details-section',
     file: 'docs/order-details-section.mdx',

--- a/apps/web/vibes/soul/sections.ts
+++ b/apps/web/vibes/soul/sections.ts
@@ -188,6 +188,12 @@ export const sections = [
     files: ['sections/inline-email-form/index.tsx'],
   },
   {
+    name: 'not-found',
+    dependencies: [],
+    registryDependencies: ['section-layout'],
+    files: ['sections/not-found/index.tsx'],
+  },
+  {
     name: 'order-history-section',
     dependencies: ['clsx'],
     registryDependencies: [],

--- a/apps/web/vibes/soul/sections/not-found/index.tsx
+++ b/apps/web/vibes/soul/sections/not-found/index.tsx
@@ -1,20 +1,37 @@
-interface Props {
+import { SectionLayout } from '@/vibes/soul/sections/section-layout';
+
+export interface NotFoundProps {
   title?: string;
   subtitle?: string;
 }
 
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --not-found-font-family: var(--font-family-body);
+ *   --not-found-title-font-family: var(--font-family-heading);
+ *   --not-found-title: hsl(var(--foreground));
+ *   --not-found-subtitle: hsl(var(--contrast-500));
+ * }
+ * ```
+ */
 export function NotFound({
   title = 'Not found',
   subtitle = "Take a look around if you're lost.",
-}: Props) {
+}: NotFoundProps) {
   return (
-    <section className="@container">
-      <div className="mx-auto max-w-3xl px-4 pt-10 @xl:px-6 @xl:pt-14 @4xl:px-8 @4xl:pt-20">
-        <h1 className="mb-3 font-heading text-3xl font-medium leading-none @xl:text-4xl @4xl:text-5xl">
+    <SectionLayout containerSize="2xl">
+      <header className="font-[family-name:var(--not-found-font-family,var(--font-family-body))]">
+        <h1 className="mb-3 font-[family-name:var(--not-found-title-font-family,var(--font-family-heading))] text-3xl font-medium leading-none text-[var(--not-found-title,hsl(var(--foreground)))] @xl:text-4xl @4xl:text-5xl">
           {title}
         </h1>
-        <p className="text-lg text-contrast-500">{subtitle}</p>
-      </div>
-    </section>
+        <p className="text-lg text-[var(--not-found-subtitle,hsl(var(--contrast-500)))]">
+          {subtitle}
+        </p>
+      </header>
+    </SectionLayout>
   );
 }


### PR DESCRIPTION
## What/Why
- adds `NotFound` placeholder doc
- exports prop interface
- adds CSS vars