### PR TITLE
audit: icon block

### DIFF
--- a/apps/web/vibes/soul/docs/icon-block.mdx
+++ b/apps/web/vibes/soul/docs/icon-block.mdx
@@ -1,7 +1,7 @@
 ---
 title: Icon Block
 preview: icon-block-example
-previewSize: lg
+previewSize: sm
 ---
 
 ## Usage
@@ -9,12 +9,35 @@ previewSize: lg
 {/* prettier-ignore-start */}
 
 <CodeBlock lang="ts">{`
+import { IconBlock } from '@/vibes/soul/sections/icon-block';
 
 function Usage() {
     return (
-
+        <IconBlock list={list} />
     );
 }
+const list= [
+    {
+      icon: 'truck',
+      title: 'Free Shipping',
+      description: 'On orders over $250',
+    },
+    {
+      icon: 'rotate-ccw',
+      title: 'Free Returns',
+      description: 'On full priced items only',
+    },
+    {
+      icon: 'star',
+      title: '2 Year Warranty',
+      description: 'As standard',
+    },
+    {
+      icon: 'truck',
+      title: 'Free Shipping',
+      description: 'On orders over $250',
+    },
+];
 `}
 </CodeBlock>
 
@@ -22,11 +45,21 @@ function Usage() {
 
 ## API Reference
 
-###
+### IconBlockProps
 
-| Prop    | Type        | Default |
-| ------- | ----------- | ------- |
-| `list*` | `ReactNode` |         |
+| Prop    | Type                                                 | Default |
+| ------- | ---------------------------------------------------- | ------- |
+| `list*` | `ListItem[]` <Tooltip content="See ListItem below"/> |         |
+
+### ListItem
+
+| Prop           | Type                                                                              | Default |
+| -------------- | --------------------------------------------------------------------------------- | ------- |
+| `icon*`        | `IconName` <Tooltip content="See the Lucide docs for a full list of icon names"/> |         |
+| `title*`       | `string`                                                                          |         |
+| `description*` | `string`                                                                          |         |
+
+Refer to the [Lucide docs](https://lucide.dev/icons/) for a full list of available icons.
 
 ### CSS Variables
 
@@ -42,7 +75,3 @@ This component supports various CSS variables for theming. Here's a comprehensiv
   --icon-block-icon: hsl(var(--foreground));
 }
 ```
-
-## Figma
-
-<Figma url="" />

--- a/apps/web/vibes/soul/docs/icon-block.mdx
+++ b/apps/web/vibes/soul/docs/icon-block.mdx
@@ -3,3 +3,46 @@ title: Icon Block
 preview: icon-block-example
 previewSize: lg
 ---
+
+## Usage
+
+{/* prettier-ignore-start */}
+
+<CodeBlock lang="ts">{`
+
+function Usage() {
+    return (
+
+    );
+}
+`}
+</CodeBlock>
+
+{/* prettier-ignore-end */}
+
+## API Reference
+
+###
+
+| Prop    | Type        | Default |
+| ------- | ----------- | ------- |
+| `list*` | `ReactNode` |         |
+
+### CSS Variables
+
+This component supports various CSS variables for theming. Here's a comprehensive list.
+
+```css
+:root {
+  --icon-block-background: hsl(var(--background));
+  --icon-block-border: hsl(var(--contrast-100));
+  --icon-block-font-family: var(--font-family-body);
+  --icon-block-title: hsl(var(--foreground));
+  --icon-block-description: hsl(var(--contrast-400));
+  --icon-block-icon: hsl(var(--foreground));
+}
+```
+
+## Figma
+
+<Figma url="" />

--- a/apps/web/vibes/soul/examples/sections/icon-block/index.tsx
+++ b/apps/web/vibes/soul/examples/sections/icon-block/index.tsx
@@ -1,65 +1,6 @@
 import { IconBlock, IconBlockProps } from '@/vibes/soul/sections/icon-block';
 
 export default function Preview() {
-  const listOf6: IconBlockProps['list'] = [
-    {
-      icon: 'truck',
-      title: 'Free Shipping',
-      description: 'On orders over $250',
-    },
-    {
-      icon: 'rotate-ccw',
-      title: 'Free Returns',
-      description: 'On full priced items only',
-    },
-    {
-      icon: 'star',
-      title: '2 Year Warranty',
-      description: 'As standard',
-    },
-    {
-      icon: 'truck',
-      title: 'Free Shipping',
-      description: 'On orders over $250',
-    },
-    {
-      icon: 'rotate-ccw',
-      title: 'Free Returns',
-      description: 'On full priced items only',
-    },
-    {
-      icon: 'star',
-      title: '2 Year Warranty',
-      description: 'As standard',
-    },
-  ];
-  const listOf5: IconBlockProps['list'] = [
-    {
-      icon: 'truck',
-      title: 'Free Shipping',
-      description: 'On orders over $250',
-    },
-    {
-      icon: 'rotate-ccw',
-      title: 'Free Returns',
-      description: 'On full priced items only',
-    },
-    {
-      icon: 'star',
-      title: '2 Year Warranty',
-      description: 'As standard',
-    },
-    {
-      icon: 'truck',
-      title: 'Free Shipping',
-      description: 'On orders over $250',
-    },
-    {
-      icon: 'rotate-ccw',
-      title: 'Free Returns',
-      description: 'On full priced items only',
-    },
-  ];
   const listOf4: IconBlockProps['list'] = [
     {
       icon: 'truck',
@@ -82,30 +23,10 @@ export default function Preview() {
       description: 'On orders over $250',
     },
   ];
-  const listOf3: IconBlockProps['list'] = [
-    {
-      icon: 'truck',
-      title: 'Free Shipping',
-      description: 'On orders over $250',
-    },
-    {
-      icon: 'rotate-ccw',
-      title: 'Free Returns',
-      description: 'On full priced items only',
-    },
-    {
-      icon: 'star',
-      title: '2 Year Warranty',
-      description: 'As standard',
-    },
-  ];
 
   return (
-    <div className="flex flex-col gap-2">
-      <IconBlock list={listOf6} />
-      <IconBlock list={listOf5} />
+    <div className="p-10">
       <IconBlock list={listOf4} />
-      <IconBlock list={listOf3} />
     </div>
   );
 }

--- a/apps/web/vibes/soul/sections.ts
+++ b/apps/web/vibes/soul/sections.ts
@@ -207,8 +207,8 @@ export const sections = [
   {
     name: 'icon-block',
     dependencies: ['clsx', 'lucide-react'],
-    registryDependencies: [],
-    files: ['sections/icon-block/index.tsx', 'primitives/icon/index.tsx'],
+    registryDependencies: ['icon'],
+    files: ['sections/icon-block/index.tsx'],
   },
   {
     name: 'inline-email-form',

--- a/apps/web/vibes/soul/sections/icon-block/index.tsx
+++ b/apps/web/vibes/soul/sections/icon-block/index.tsx
@@ -10,25 +10,41 @@ export interface IconBlockProps {
   }>;
 }
 
+/**
+ * This component supports various CSS variables for theming. Here's a comprehensive list, along
+ * with their default values:
+ *
+ * ```css
+ * :root {
+ *   --icon-block-background: hsl(var(--background));
+ *   --icon-block-border: hsl(var(--contrast-100));
+ *   --icon-block-font-family: var(--font-family-body);
+ *   --icon-block-title: hsl(var(--foreground));
+ *   --icon-block-description: hsl(var(--contrast-400));
+ *   --icon-block-icon: hsl(var(--foreground));
+ * }
+ * ```
+ */
 export const IconBlock = function IconBlock({ list }: IconBlockProps) {
   return (
-    <section className="bg-background text-foreground @container">
-      <ul className="mx-auto flex w-full max-w-screen-2xl flex-wrap justify-center divide-y divide-contrast-100 px-3 @2xl:px-20">
+    <section className="bg-[var(--icon-block-background,hsl(var(--background)))] font-[family-name:var(--icon-block-font-family,var(--font-family-body))] @container">
+      <ul className="mx-auto flex w-full max-w-screen-2xl flex-wrap justify-center px-3 @2xl:px-20">
         {list.map(({ title, description, icon }, idx) => {
           return (
             <li
               className={clsx(
-                'flex flex-col items-center gap-2 px-1 py-10',
-                list.length !== 4 ? 'w-full @md:w-1/2 @xl:w-1/3' : 'w-1/4',
-                { 'border-t border-contrast-100': idx === 0 },
+                'border-[var(--icon-block-border,hsl(var(--contrast-100))] flex w-full flex-col items-center gap-2 border-t px-1 py-10 @md:w-1/2 @xl:w-1/3 @2xl:w-1/4',
               )}
               key={idx}
             >
-              <Icon name={icon} />
-
+              <Icon className="text-[var(--icon-block-icon,hsl(var(--foreground)))]" name={icon} />
               <div className="flex flex-col items-center text-center">
-                <span>{title}</span>
-                <span className="opacity-40">{description}</span>
+                <span className="text-[var(--icon-block-title,hsl(var(--foreground)))]">
+                  {title}
+                </span>
+                <span className="text-[var(--icon-block-description,hsl(var(--contrast-400)))]">
+                  {description}
+                </span>
               </div>
             </li>
           );


### PR DESCRIPTION
## What / Why
- adds css vars
- exports props interface
- simplifies some CSS choices like using `border` instead of a weird combo of `divider` and `border`