### PR TITLE
feat: add compare drawer functionality

### DIFF
--- a/apps/web/vibes/soul/examples/primitives/compare-drawer/electric.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-drawer/electric.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { CompareDrawer, CompareDrawerContext, useCompareDrawer } from '@/vibes/soul/primitives/compare-drawer';
+import { CompareDrawer, CompareDrawerProvider } from '@/vibes/soul/primitives/compare-drawer';
 
 export default function Preview() {
-
   return (
-    <CompareDrawerContext value={{ optimisticItems: compareProducts, setOptimisticItems: () => {} }}>
+    <CompareDrawerProvider items={compareProducts}>
       <div className="relative h-screen">
-        <CompareDrawer  />
+        <CompareDrawer />
       </div>
-    </CompareDrawerContext>
+    </CompareDrawerProvider>
   );
 }
 

--- a/apps/web/vibes/soul/examples/primitives/compare-drawer/electric.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-drawer/electric.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import { CompareDrawer } from '@/vibes/soul/primitives/compare-drawer';
+import { CompareDrawer, CompareDrawerContext, useCompareDrawer } from '@/vibes/soul/primitives/compare-drawer';
 
 export default function Preview() {
+
   return (
-    <div className="relative h-screen">
-      <CompareDrawer items={compareProducts} />
-    </div>
+    <CompareDrawerContext value={{ optimisticItems: compareProducts, setOptimisticItems: () => {} }}>
+      <div className="relative h-screen">
+        <CompareDrawer  />
+      </div>
+    </CompareDrawerContext>
   );
 }
 

--- a/apps/web/vibes/soul/examples/primitives/compare-drawer/luxury.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-drawer/luxury.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { CompareDrawer, CompareDrawerContext } from '@/vibes/soul/primitives/compare-drawer';
+import { CompareDrawer, CompareDrawerProvider } from '@/vibes/soul/primitives/compare-drawer';
 
 export default function Preview() {
   return (
-    <CompareDrawerContext value={{ optimisticItems: compareProducts, setOptimisticItems: () => {} }}>
+    <CompareDrawerProvider items={compareProducts}>
       <div className="relative h-screen">
-        <CompareDrawer  />
+        <CompareDrawer />
       </div>
-    </CompareDrawerContext>
+    </CompareDrawerProvider>
   );
 }
 

--- a/apps/web/vibes/soul/examples/primitives/compare-drawer/luxury.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-drawer/luxury.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { CompareDrawer } from '@/vibes/soul/primitives/compare-drawer';
+import { CompareDrawer, CompareDrawerContext } from '@/vibes/soul/primitives/compare-drawer';
 
 export default function Preview() {
   return (
-    <div className="relative h-screen">
-      <CompareDrawer items={compareProducts} />
-    </div>
+    <CompareDrawerContext value={{ optimisticItems: compareProducts, setOptimisticItems: () => {} }}>
+      <div className="relative h-screen">
+        <CompareDrawer  />
+      </div>
+    </CompareDrawerContext>
   );
 }
 

--- a/apps/web/vibes/soul/examples/primitives/compare-drawer/warm.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-drawer/warm.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { CompareDrawer, CompareDrawerContext } from '@/vibes/soul/primitives/compare-drawer';
+import { CompareDrawer, CompareDrawerProvider } from '@/vibes/soul/primitives/compare-drawer';
 
 export default function Preview() {
   return (
-    <CompareDrawerContext value={{ optimisticItems: compareProducts, setOptimisticItems: () => {} }}>
+    <CompareDrawerProvider items={compareProducts}>
       <div className="relative h-screen">
-        <CompareDrawer  />
+        <CompareDrawer />
       </div>
-    </CompareDrawerContext>
+    </CompareDrawerProvider>
   );
 }
 

--- a/apps/web/vibes/soul/examples/primitives/compare-drawer/warm.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-drawer/warm.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { CompareDrawer } from '@/vibes/soul/primitives/compare-drawer';
+import { CompareDrawer, CompareDrawerContext } from '@/vibes/soul/primitives/compare-drawer';
 
 export default function Preview() {
   return (
-    <div className="relative h-screen">
-      <CompareDrawer items={compareProducts} />
-    </div>
+    <CompareDrawerContext value={{ optimisticItems: compareProducts, setOptimisticItems: () => {} }}>
+      <div className="relative h-screen">
+        <CompareDrawer  />
+      </div>
+    </CompareDrawerContext>
   );
 }
 

--- a/apps/web/vibes/soul/examples/sections/compare-section/actions.ts
+++ b/apps/web/vibes/soul/examples/sections/compare-section/actions.ts
@@ -1,7 +1,0 @@
-'use server';
-
-export async function addToCartAction(id: string) {
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-
-  console.log('Add to cart:', id);
-}

--- a/apps/web/vibes/soul/examples/sections/compare-section/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/compare-section/electric.tsx
@@ -8,7 +8,6 @@ export default function Preview() {
 
   return (
     <CompareSection
-      addToCartAction={addToCartAction}
       emptyStateSubtitle="Browse our catalog to find products."
       emptyStateTitle="No products to compare"
       products={products}

--- a/apps/web/vibes/soul/examples/sections/compare-section/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/compare-section/luxury.tsx
@@ -8,7 +8,6 @@ export default function Preview() {
 
   return (
     <CompareSection
-      addToCartAction={addToCartAction}
       emptyStateSubtitle="Browse our catalog to find products."
       emptyStateTitle="No products to compare"
       products={products}

--- a/apps/web/vibes/soul/examples/sections/compare-section/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/compare-section/warm.tsx
@@ -8,7 +8,6 @@ export default function Preview() {
 
   return (
     <CompareSection
-      addToCartAction={addToCartAction}
       emptyStateSubtitle="Browse our catalog to find products."
       emptyStateTitle="No products to compare"
       products={products}

--- a/apps/web/vibes/soul/primitives/compare-card/add-to-cart-form.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/add-to-cart-form.tsx
@@ -28,9 +28,9 @@ export function AddToCartForm({
   productId,
   addToCartLabel,
   addToCartAction,
-  isPreorder,
+  isPreorder = false,
   preorderLabel,
-  disabled,
+  disabled = false,
 }: Props) {
   const [{ lastResult, successMessage }, formAction, pending] = useActionState(addToCartAction, {
     lastResult: null,

--- a/apps/web/vibes/soul/primitives/compare-card/add-to-cart-form.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/add-to-cart-form.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { SubmissionResult, useForm } from '@conform-to/react';
+import { ReactNode, useActionState, useEffect } from 'react';
+
+import { Button } from '@/vibes/soul/primitives/button';
+import { toast } from '@/vibes/soul/primitives/toaster';
+
+type Action<S, P> = (state: Awaited<S>, payload: P) => S | Promise<S>;
+
+interface State {
+  lastResult: SubmissionResult | null;
+  successMessage?: ReactNode;
+}
+
+export type CompareAddToCartAction = Action<State, FormData>;
+
+interface Props {
+  disabled?: boolean;
+  productId: string;
+  addToCartLabel: string;
+  preorderLabel: string;
+  isPreorder?: boolean;
+  addToCartAction: CompareAddToCartAction;
+}
+
+export function AddToCartForm({
+  productId,
+  addToCartLabel,
+  addToCartAction,
+  isPreorder,
+  preorderLabel,
+  disabled,
+}: Props) {
+  const [{ lastResult, successMessage }, formAction, pending] = useActionState(addToCartAction, {
+    lastResult: null,
+    successMessage: undefined,
+  });
+
+  const [form] = useForm({ lastResult });
+
+  useEffect(() => {
+    if (lastResult?.status === 'success') {
+      toast.success(successMessage);
+    }
+  }, [lastResult, successMessage]);
+
+  useEffect(() => {
+    if (form.errors) {
+      form.errors.forEach((error) => {
+        toast.error(error);
+      });
+    }
+  }, [form.errors]);
+
+  return (
+    <form action={formAction}>
+      <input name="id" type="hidden" value={productId} />
+      <Button className="w-full" disabled={disabled} loading={pending} size="medium" type="submit">
+        {isPreorder ? preorderLabel : addToCartLabel}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/vibes/soul/primitives/compare-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/index.tsx
@@ -76,7 +76,7 @@ export function CompareCard({
       <div className="mb-2 space-y-4 pb-4">
         <ProductCard imageSizes={imageSizes} product={product} />
         {addToCartAction &&
-          (!product.hasVariants ? (
+          (product.hasVariants !== undefined && !product.hasVariants ? (
             <AddToCartForm
               addToCartAction={addToCartAction}
               addToCartLabel={addToCartLabel}

--- a/apps/web/vibes/soul/primitives/compare-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/index.tsx
@@ -1,6 +1,5 @@
 import { clsx } from 'clsx';
 
-import { Button } from '@/vibes/soul/primitives/button';
 import {
   type Product,
   ProductCard,
@@ -9,9 +8,16 @@ import {
 import { Rating } from '@/vibes/soul/primitives/rating';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
+import { ButtonLink } from '@/vibes/soul/primitives/button-link';
+
+import { AddToCartForm, CompareAddToCartAction } from './add-to-cart-form';
+
 export interface CompareProduct extends Product {
-  description?: string;
+  description?: string | React.ReactNode;
   customFields?: Array<{ name: string; value: string }>;
+  hasVariants?: boolean;
+  disabled?: boolean;
+  isPreorder?: boolean;
 }
 
 export interface CompareCardProps {
@@ -19,9 +25,14 @@ export interface CompareCardProps {
   product: CompareProduct;
   addToCartLabel?: string;
   descriptionLabel?: string;
+  noDescriptionLabel?: string;
   ratingLabel?: string;
+  noRatingsLabel?: string;
   otherDetailsLabel?: string;
-  addToCartAction?: (id: string) => Promise<void>;
+  noOtherDetailsLabel?: string;
+  viewOptionsLabel?: string;
+  preorderLabel?: string;
+  addToCartAction?: CompareAddToCartAction;
   imageSizes?: string;
 }
 
@@ -46,8 +57,13 @@ export function CompareCard({
   addToCartAction,
   addToCartLabel = 'Add to cart',
   descriptionLabel = 'Description',
+  noDescriptionLabel = 'There is no description available.',
   ratingLabel = 'Rating',
+  noRatingsLabel = 'There are no reviews.',
   otherDetailsLabel = 'Other details',
+  noOtherDetailsLabel = 'There are no other details.',
+  viewOptionsLabel = 'View options',
+  preorderLabel = 'Preorder',
   imageSizes,
 }: CompareCardProps) {
   return (
@@ -59,13 +75,21 @@ export function CompareCard({
     >
       <div className="mb-2 space-y-4 pb-4">
         <ProductCard imageSizes={imageSizes} product={product} />
-        {addToCartAction && (
-          <form action={addToCartAction.bind(null, product.id)}>
-            <Button className="w-full" size="medium" type="submit">
-              {addToCartLabel}
-            </Button>
-          </form>
-        )}
+        {addToCartAction &&
+          (!product.hasVariants ? (
+            <AddToCartForm
+              addToCartAction={addToCartAction}
+              addToCartLabel={addToCartLabel}
+              disabled={product.disabled}
+              isPreorder={product.isPreorder}
+              preorderLabel={preorderLabel}
+              productId={product.id}
+            />
+          ) : (
+            <ButtonLink className="w-full" href={product.href} size="medium">
+              {viewOptionsLabel}
+            </ButtonLink>
+          ))}
       </div>
       <div className="space-y-4 py-4">
         <div className="font-[family-name:var(--compare-card-font-family-secondary,var(--font-family-mono))] text-xs font-normal uppercase text-[var(--compare-card-label,hsl(var(--foreground)))]">
@@ -75,8 +99,7 @@ export function CompareCard({
           <Rating rating={product.rating} />
         ) : (
           <p className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">
-            {' '}
-            There are no reviews.
+            {noRatingsLabel}
           </p>
         )}
       </div>
@@ -85,13 +108,12 @@ export function CompareCard({
           {descriptionLabel}
         </div>
         {product.description != null && product.description !== '' ? (
-          <p className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">
+          <div className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">
             {product.description}
-          </p>
+          </div>
         ) : (
           <p className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">
-            {' '}
-            There is no description available.
+            {noDescriptionLabel}
           </p>
         )}
       </div>
@@ -114,8 +136,7 @@ export function CompareCard({
             {otherDetailsLabel}
           </div>
           <p className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">
-            {' '}
-            There are no other details available.
+            {noOtherDetailsLabel}
           </p>
         </div>
       )}

--- a/apps/web/vibes/soul/primitives/compare-card/schema.ts
+++ b/apps/web/vibes/soul/primitives/compare-card/schema.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const compareAddToCartFormDataSchema = z.object({
+  id: z.string(),
+});

--- a/apps/web/vibes/soul/primitives/compare-drawer/loader.tsx
+++ b/apps/web/vibes/soul/primitives/compare-drawer/loader.tsx
@@ -1,0 +1,9 @@
+import { createLoader, parseAsArrayOf, parseAsString } from 'nuqs/server';
+
+export const compareParser = parseAsArrayOf(parseAsString).withOptions({
+  shallow: false,
+  scroll: false,
+});
+
+export const createCompareLoader = (paramName = 'compare') =>
+  createLoader({ [paramName]: compareParser });

--- a/apps/web/vibes/soul/primitives/product-card/compare.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/compare.tsx
@@ -48,7 +48,7 @@ export const Compare = function Compare({
 
           startTransition(() => {
             setOptimisticItems({
-              type: value ? 'add' : 'remove',
+              type: value === true ? 'add' : 'remove',
               item: product,
             });
           });

--- a/apps/web/vibes/soul/primitives/product-card/compare.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/compare.tsx
@@ -1,38 +1,57 @@
 'use client';
 
 import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs';
+import { startTransition } from 'react';
 
 import { Checkbox } from '@/vibes/soul/form/checkbox';
 
+import { useCompareDrawer } from '../compare-drawer';
+
+interface CompareDrawerItem {
+  id: string;
+  image?: { src: string; alt: string };
+  href: string;
+  title: string;
+}
+
 interface Props {
-  productId: string;
   colorScheme?: 'light' | 'dark';
   paramName?: string;
   label?: string;
+  product: CompareDrawerItem;
 }
 
 export const Compare = function Compare({
-  productId,
   colorScheme = 'light',
   paramName = 'compare',
   label = 'Compare',
+  product,
 }: Props) {
-  const [param, setParam] = useQueryState(
+  const [, setParam] = useQueryState(
     paramName,
     parseAsArrayOf(parseAsString).withOptions({ shallow: false }),
   );
 
+  const { optimisticItems, setOptimisticItems } = useCompareDrawer();
+
   return (
     <Checkbox
-      checked={param?.includes(productId) ?? false}
+      checked={!!optimisticItems.find((item) => item.id === product.id)}
       colorScheme={colorScheme}
       label={label}
       onCheckedChange={(value) => {
         void setParam((prev) => {
           const next =
             value === true
-              ? [...(prev ?? []), productId]
-              : (prev ?? []).filter((v) => v !== productId);
+              ? [...(prev ?? []), product.id]
+              : (prev ?? []).filter((v) => v !== product.id);
+
+          startTransition(() => {
+            setOptimisticItems({
+              type: value ? 'add' : 'remove',
+              item: product,
+            });
+          });
 
           return next.length > 0 ? next : null;
         });

--- a/apps/web/vibes/soul/primitives/product-card/compare.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/compare.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs';
+import { useQueryState } from 'nuqs';
 import { startTransition } from 'react';
 
 import { Checkbox } from '@/vibes/soul/form/checkbox';
-
-import { useCompareDrawer } from '../compare-drawer';
+import { useCompareDrawer } from '@/vibes/soul/primitives/compare-drawer';
+import { compareParser } from '@/vibes/soul/primitives/compare-drawer/loader';
 
 interface CompareDrawerItem {
   id: string;
@@ -27,33 +27,35 @@ export const Compare = function Compare({
   label = 'Compare',
   product,
 }: Props) {
-  const [, setParam] = useQueryState(
-    paramName,
-    parseAsArrayOf(parseAsString).withOptions({ shallow: false }),
-  );
+  const [, setParam] = useQueryState(paramName, compareParser);
 
-  const { optimisticItems, setOptimisticItems } = useCompareDrawer();
+  const { optimisticItems, setOptimisticItems, maxItems } = useCompareDrawer();
 
   return (
     <Checkbox
       checked={!!optimisticItems.find((item) => item.id === product.id)}
       colorScheme={colorScheme}
+      disabled={
+        !optimisticItems.find((item) => item.id === product.id) &&
+        maxItems !== undefined &&
+        optimisticItems.length >= maxItems
+      }
       label={label}
       onCheckedChange={(value) => {
-        void setParam((prev) => {
-          const next =
-            value === true
-              ? [...(prev ?? []), product.id]
-              : (prev ?? []).filter((v) => v !== product.id);
-
-          startTransition(() => {
-            setOptimisticItems({
-              type: value === true ? 'add' : 'remove',
-              item: product,
-            });
+        startTransition(async () => {
+          setOptimisticItems({
+            type: value === true ? 'add' : 'remove',
+            item: product,
           });
 
-          return next.length > 0 ? next : null;
+          await setParam((prev) => {
+            const next =
+              value === true
+                ? [...(prev ?? []), product.id]
+                : (prev ?? []).filter((v) => v !== product.id);
+
+            return next.length > 0 ? next : null;
+          });
         });
       }}
     />

--- a/apps/web/vibes/soul/primitives/product-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/index.tsx
@@ -169,7 +169,7 @@ export function ProductCard({
             colorScheme={colorScheme}
             label={compareLabel}
             paramName={compareParamName}
-            productId={id}
+            product={{ id, title, href, image }}
           />
         </div>
       )}

--- a/apps/web/vibes/soul/sections/compare-section/index.tsx
+++ b/apps/web/vibes/soul/sections/compare-section/index.tsx
@@ -15,7 +15,9 @@ import {
 } from '@/vibes/soul/primitives/compare-card';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
-export interface CompareSectionProps {
+import { CompareAddToCartAction } from '@/vibes/soul/primitives/compare-card/add-to-cart-form';
+
+interface CompareSectionProps {
   className?: string;
   title?: string;
   products: Streamable<CompareProduct[]>;
@@ -24,8 +26,16 @@ export interface CompareSectionProps {
   addToCartLabel?: string;
   previousLabel?: string;
   nextLabel?: string;
-  addToCartAction?: (id: string) => Promise<void>;
+  descriptionLabel?: string;
+  noDescriptionLabel?: string;
+  ratingLabel?: string;
+  noRatingsLabel?: string;
+  otherDetailsLabel?: string;
+  noOtherDetailsLabel?: string;
+  viewOptionsLabel?: string;
+  preorderLabel?: string;
   placeholderCount?: number;
+  addToCartAction?: CompareAddToCartAction;
 }
 
 /**
@@ -54,9 +64,23 @@ export function CompareSection({
   emptyStateSubtitle = 'Browse our catalog to find products.',
   previousLabel,
   nextLabel,
+  descriptionLabel,
+  noDescriptionLabel,
+  ratingLabel,
+  noRatingsLabel,
+  otherDetailsLabel,
+  noOtherDetailsLabel,
+  viewOptionsLabel,
+  preorderLabel,
+  placeholderCount,
 }: CompareSectionProps) {
   return (
-    <Stream fallback={<CompareSectionSkeleton className={className} />} value={streamableProducts}>
+    <Stream
+      fallback={
+        <CompareSectionSkeleton className={className} placeholderCount={placeholderCount} />
+      }
+      value={streamableProducts}
+    >
       {(products) => {
         if (products.length === 0) {
           return (
@@ -64,6 +88,7 @@ export function CompareSection({
               className={className}
               emptyStateSubtitle={emptyStateSubtitle}
               emptyStateTitle={emptyStateTitle}
+              placeholderCount={placeholderCount}
             />
           );
         }
@@ -94,9 +119,17 @@ export function CompareSection({
                       <CompareCard
                         addToCartAction={addToCartAction}
                         addToCartLabel={addToCartLabel}
+                        descriptionLabel={descriptionLabel}
                         imageSizes="(min-width: 42rem) 25vw, (min-width: 32rem) 33vw, (min-width: 28rem) 50vw, 100vw"
                         key={product.id}
+                        noDescriptionLabel={noDescriptionLabel}
+                        noOtherDetailsLabel={noOtherDetailsLabel}
+                        noRatingsLabel={noRatingsLabel}
+                        otherDetailsLabel={otherDetailsLabel}
+                        preorderLabel={preorderLabel}
                         product={product}
+                        ratingLabel={ratingLabel}
+                        viewOptionsLabel={viewOptionsLabel}
                       />
                     </CarouselItem>
                   ))}

--- a/apps/web/vibes/soul/sections/featured-product-list/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-product-list/index.tsx
@@ -69,6 +69,7 @@ export function FeaturedProductList({
           emptyStateTitle={emptyStateTitle}
           placeholderCount={placeholderCount}
           products={products}
+          showCompare={false}
         />
       </div>
     </StickySidebarLayout>

--- a/apps/web/vibes/soul/sections/product-list-section/index.tsx
+++ b/apps/web/vibes/soul/sections/product-list-section/index.tsx
@@ -1,5 +1,4 @@
 import { Sliders } from 'lucide-react';
-import { ComponentProps } from 'react';
 
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { Button } from '@/vibes/soul/primitives/button';
@@ -44,6 +43,7 @@ export interface ProductListSectionProps {
   emptyStateSubtitle?: Streamable<string>;
   emptyStateTitle?: Streamable<string>;
   placeholderCount?: number;
+  removeLabel?: Streamable<string>;
 }
 
 /**
@@ -87,6 +87,7 @@ export function ProductListSection({
   emptyStateSubtitle,
   emptyStateTitle,
   placeholderCount = 8,
+  removeLabel,
 }: ProductListSectionProps) {
   return (
     <div className="group/product-list-section @container">
@@ -183,6 +184,7 @@ export function ProductListSection({
               emptyStateTitle={emptyStateTitle}
               placeholderCount={placeholderCount}
               products={products}
+              removeLabel={removeLabel}
               showCompare={showCompare}
             />
 

--- a/apps/web/vibes/soul/sections/product-list-section/index.tsx
+++ b/apps/web/vibes/soul/sections/product-list-section/index.tsx
@@ -29,8 +29,9 @@ export interface ProductListSectionProps {
   sortOptions: Streamable<SortOption[]>;
   compareProducts?: Streamable<Product[]>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
-  compareAction?: ComponentProps<'form'>['action'];
+  compareHref?: string;
   compareLabel?: Streamable<string>;
+  showCompare?: Streamable<boolean>;
   filterLabel?: string;
   filtersPanelTitle?: Streamable<string>;
   resetFiltersLabel?: Streamable<string>;
@@ -71,8 +72,9 @@ export function ProductListSection({
   sortOptions: streamableSortOptions,
   sortDefaultValue,
   filters,
-  compareAction,
+  compareHref,
   compareLabel,
+  showCompare,
   paginationInfo,
   filterLabel = 'Filters',
   filtersPanelTitle: streamableFiltersPanelTitle = 'Filters',
@@ -173,7 +175,7 @@ export function ProductListSection({
 
           <div className="flex-1 group-has-[[data-pending]]/product-list-section:animate-pulse">
             <ProductList
-              compareAction={compareAction}
+              compareHref={compareHref}
               compareLabel={compareLabel}
               compareParamName={compareParamName}
               compareProducts={compareProducts}
@@ -181,7 +183,7 @@ export function ProductListSection({
               emptyStateTitle={emptyStateTitle}
               placeholderCount={placeholderCount}
               products={products}
-              showCompare
+              showCompare={showCompare}
             />
 
             {paginationInfo && <CursorPagination info={paginationInfo} />}

--- a/apps/web/vibes/soul/sections/product-list/index.tsx
+++ b/apps/web/vibes/soul/sections/product-list/index.tsx
@@ -22,6 +22,9 @@ interface ProductListProps {
   emptyStateTitle?: Streamable<string>;
   emptyStateSubtitle?: Streamable<string>;
   placeholderCount?: number;
+  removeLabel?: Streamable<string>;
+  maxItems?: number;
+  maxCompareLimitMessage?: Streamable<string>;
 }
 
 /**
@@ -52,6 +55,9 @@ export function ProductList({
   emptyStateTitle = 'No products found',
   emptyStateSubtitle = 'Try browsing our complete catalog of products.',
   placeholderCount = 8,
+  removeLabel: streamableRemoveLabel,
+  maxItems,
+  maxCompareLimitMessage: streamableMaxCompareLimitMessage,
 }: ProductListProps) {
   return (
     <Stream
@@ -61,9 +67,18 @@ export function ProductList({
         streamableCompareLabel,
         streamableShowCompare,
         streamableCompareProducts,
+        streamableRemoveLabel,
+        streamableMaxCompareLimitMessage,
       ])}
     >
-      {([products, compareLabel, showCompare, compareProducts]) => {
+      {([
+        products,
+        compareLabel,
+        showCompare,
+        compareProducts,
+        removeLabel,
+        maxCompareLimitMessage,
+      ]) => {
         if (products.length === 0) {
           return (
             <ProductListEmptyState
@@ -75,7 +90,11 @@ export function ProductList({
         }
 
         return (
-          <CompareDrawerProvider items={compareProducts}>
+          <CompareDrawerProvider
+            items={compareProducts}
+            maxCompareLimitMessage={maxCompareLimitMessage}
+            maxItems={maxItems}
+          >
             <div className={clsx('w-full @container', className)}>
               <div className="mx-auto grid grid-cols-1 gap-x-4 gap-y-6 @sm:grid-cols-2 @2xl:grid-cols-3 @2xl:gap-x-5 @2xl:gap-y-8 @5xl:grid-cols-4 @7xl:grid-cols-5">
                 {products.map((product) => (
@@ -96,6 +115,7 @@ export function ProductList({
               <CompareDrawer
                 href={compareHref}
                 paramName={compareParamName}
+                removeLabel={removeLabel}
                 submitLabel={compareLabel}
               />
             )}


### PR DESCRIPTION
- Adds compare drawer functionality to Product List section
- Instead of an action, it is now a link that redirect to specified url. Default is `/compare`.
- Compare section now is aware of showing buy buttons or links to product (for products with variants).

![Screenshot 2025-03-12 at 2 57 44 PM](https://github.com/user-attachments/assets/1595b13e-ec4e-4a18-80d6-4ea47d75fc01)
