### PR TITLE
fix: type names that used WithId naming

### DIFF
--- a/apps/web/vibes/soul/data/breadcrumbs.ts
+++ b/apps/web/vibes/soul/data/breadcrumbs.ts
@@ -1,61 +1,52 @@
-import { BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 
 import { SoulBrandName } from '../brands';
 
-export function getBreadcrumbs(brand: SoulBrandName): BreadcrumbWithId[] {
+export function getBreadcrumbs(brand: SoulBrandName): Breadcrumb[] {
   return breadcrumbs[brand];
 }
 
 const breadcrumbs = {
   Electric: [
     {
-      id: '1',
       label: 'Home',
-      href: '#',
+      href: '#1',
     },
     {
-      id: '2',
       label: 'Plants',
-      href: '#',
+      href: '#2',
     },
     {
-      id: '3',
       label: 'Indoor',
-      href: '#',
+      href: '#3',
     },
   ],
   Luxury: [
     {
-      id: '1',
       label: 'Home',
-      href: '#',
+      href: '#1',
     },
     {
-      id: '2',
       label: 'Shoes',
-      href: '#',
+      href: '#2',
     },
     {
-      id: '3',
       label: 'Flats',
-      href: '#',
+      href: '#3',
     },
   ],
   Warm: [
     {
-      id: '1',
       label: 'Home',
-      href: '#',
+      href: '#1`',
     },
     {
-      id: '2',
       label: 'Bags',
-      href: '#',
+      href: '#2',
     },
     {
-      id: '3',
       label: 'Handle Bags',
-      href: '#',
+      href: '#3',
     },
   ],
-} as const satisfies Record<SoulBrandName, [BreadcrumbWithId, ...BreadcrumbWithId[]]>;
+} as const satisfies Record<SoulBrandName, [Breadcrumb, ...Breadcrumb[]]>;

--- a/apps/web/vibes/soul/data/products.ts
+++ b/apps/web/vibes/soul/data/products.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/consistent-type-assertions */
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { Filter } from '@/vibes/soul/sections/product-list-section/filter-panel';
 
 import { SoulBrandName } from '../brands';
-import { ProductCardWithId } from '../primitives/product-card';
 
 // Common product type
 interface BaseProduct {
@@ -517,7 +517,7 @@ export async function getFilters(brand: SoulBrandName): Promise<Filter[]> {
 export async function getProducts(
   brand: SoulBrandName,
   filterParams?: FilterParams,
-): Promise<ProductCardWithId[]> {
+): Promise<Product[]> {
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   let brandProducts = products[brand] as Array<ElectricProduct | LuxuryProduct | WarmProduct>;
@@ -588,5 +588,5 @@ export async function getProducts(
     }
   }
 
-  return brandProducts as unknown as ProductCardWithId[];
+  return brandProducts as unknown as Product[];
 }

--- a/apps/web/vibes/soul/docs/blog-post-carousel.mdx
+++ b/apps/web/vibes/soul/docs/blog-post-carousel.mdx
@@ -50,23 +50,22 @@ const posts = [
 
 ### BlogPostCarouselProps
 
-| Prop                 | Type                                                                                                         | Default |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
-| `className`          | `string`                                                                                                     |         |
-| `blogPosts*`         | [`Streamable`](/docs/soul/streamable)`<BlogPostWithId[]>` <Tooltip content="see BlogPostWithId type below"/> |         |
-| `scrollbarLabel`     | `string`                                                                                                     |         |
-| `previousLabel`      | `string`                                                                                                     |         |
-| `nextLabel`          | `string`                                                                                                     |         |
-| `placeholderCount`   | `number`                                                                                                     |         |
-| `emptyStateTitle`    | [`Streamable`](/docs/soul/streamable)`<string>`                                                              |         |
-| `emptyStateSubtitle` | [`Streamable`](/docs/soul/streamable)`<string>`                                                              |         |
-| `hideOverflow`       | `boolean`                                                                                                    | `true`  |
+| Prop                 | Type                                                                                             | Default |
+| -------------------- | ------------------------------------------------------------------------------------------------ | ------- |
+| `className`          | `string`                                                                                         |         |
+| `blogPosts*`         | [`Streamable`](/docs/soul/streamable)`<BlogPost[]>` <Tooltip content="see BlogPost type below"/> |         |
+| `scrollbarLabel`     | `string`                                                                                         |         |
+| `previousLabel`      | `string`                                                                                         |         |
+| `nextLabel`          | `string`                                                                                         |         |
+| `placeholderCount`   | `number`                                                                                         |         |
+| `emptyStateTitle`    | [`Streamable`](/docs/soul/streamable)`<string>`                                                  |         |
+| `emptyStateSubtitle` | [`Streamable`](/docs/soul/streamable)`<string>`                                                  |         |
+| `hideOverflow`       | `boolean`                                                                                        | `true`  |
 
-### BlogPostWithId
+### BlogPost
 
 | Prop       | Type                                   | Default |
 | ---------- | -------------------------------------- | ------- |
-| `id*`      | `string`                               |         |
 | `title*`   | `string`                               |         |
 | `author`   | `string  \| null`                      |
 | `content*` | `string`                               |         |

--- a/apps/web/vibes/soul/docs/blog-post-content.mdx
+++ b/apps/web/vibes/soul/docs/blog-post-content.mdx
@@ -34,12 +34,12 @@ const blogPost = {
 
 ### BlogPostContentProps
 
-| Prop          | Type                                                                                                        | Default |
-| ------------- | ----------------------------------------------------------------------------------------------------------- | ------- |
-| `className`   | `string`                                                                                                    |         |
-| `blogPost*`   | [`Streamable`](/docs/soul/streamable)`<BlogPost>` <Tooltip content="See BlogPost below"/>                   |         |
-| `breadcrumbs` | [`Streamable`](/docs/soul/streamable)`<BreadcrumbWithId[]>` <Tooltip content="See BreadcrumbWithId below"/> |         |
-| `className`   | `string`                                                                                                    |         |
+| Prop          | Type                                                                                            | Default |
+| ------------- | ----------------------------------------------------------------------------------------------- | ------- |
+| `className`   | `string`                                                                                        |         |
+| `blogPost*`   | [`Streamable`](/docs/soul/streamable)`<BlogPost>` <Tooltip content="See BlogPost below"/>       |         |
+| `breadcrumbs` | [`Streamable`](/docs/soul/streamable)`<Breadcrumb[]>` <Tooltip content="See Breadcrumb below"/> |         |
+| `className`   | `string`                                                                                        |         |
 
 ### BlogPost
 
@@ -52,13 +52,12 @@ const blogPost = {
 | `content*` | `string`                               |         |
 | `image`    | `{ src: string, alt: string } \| null` |         |
 
-### BreadcrumbWithId
+### Breadcrumb
 
 | Prop     | Type     | Default |
 | -------- | -------- | ------- |
 | `label*` | `string` |         |
 | `href*`  | `string` |         |
-| `id*`    | `string` |         |
 
 ### Tag
 

--- a/apps/web/vibes/soul/docs/blog-post-list.mdx
+++ b/apps/web/vibes/soul/docs/blog-post-list.mdx
@@ -45,20 +45,19 @@ const blogPosts = [
 
 ### BlogPostListProps
 
-| Prop                 | Type                                                                                                   | Default |
-| -------------------- | ------------------------------------------------------------------------------------------------------ | ------- |
-| `className`          | `string`                                                                                               |         |
-| `blogPosts*`         | [`Streamable`](docs/soul/streamable)`<BlogPostWithId[]>` <Tooltip content="See BlogPostWithId below"/> |         |
-| `className`          | `string`                                                                                               |         |
-| `emptyStateSubtitle` | [`Streamable`](docs/soul/streamable)`<string>`                                                         |         |
-| `emptyStateTitle`    | [`Streamable`](docs/soul/streamable)`<string>`                                                         |         |
-| `placeholderCount`   | `number`                                                                                               |         |
+| Prop                 | Type                                                                                       | Default |
+| -------------------- | ------------------------------------------------------------------------------------------ | ------- |
+| `className`          | `string`                                                                                   |         |
+| `blogPosts*`         | [`Streamable`](docs/soul/streamable)`<BlogPost[]>` <Tooltip content="See BlogPost below"/> |         |
+| `className`          | `string`                                                                                   |         |
+| `emptyStateSubtitle` | [`Streamable`](docs/soul/streamable)`<string>`                                             |         |
+| `emptyStateTitle`    | [`Streamable`](docs/soul/streamable)`<string>`                                             |         |
+| `placeholderCount`   | `number`                                                                                   |         |
 
-### BlogPostWithId
+### BlogPost
 
 | Prop       | Type                                   | Default |
 | ---------- | -------------------------------------- | ------- |
-| `id*`      | `string`                               |         |
 | `title*`   | `string`                               |         |
 | `author`   | `string  \| null`                      |
 | `content*` | `string`                               |         |

--- a/apps/web/vibes/soul/docs/breadcrumbs.mdx
+++ b/apps/web/vibes/soul/docs/breadcrumbs.mdx
@@ -13,25 +13,22 @@ previewSize: xs
 {/* prettier-ignore-start */}
 
 <CodeBlock lang="ts">{`
-import { Breadcrumbs, BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { Breadcrumbs, type Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 
 function Usage() {
 
-    const breadcrumbs: BreadcrumbWithId[] = [
+    const breadcrumbs: Breadcrumb[] = [
       {
-        id: '1',
         label: 'Home',
-        href: '#',
+        href: '#1',
       },
       {
-        id: '2',
         label: 'Bags',
-        href: '#',
+        href: '#2',
       },
       {
-        id: '3',
         label: 'Handle Bags',
-        href: '#',
+        href: '#3',
       },
     ];
 
@@ -48,16 +45,15 @@ function Usage() {
 
 ### BreadcrumbsProps
 
-| Prop           | Type                                                                                                      | Default |
-| -------------- | --------------------------------------------------------------------------------------------------------- | ------- |
-| `breadcrumbs*` | [Streamable](/docs/soul/streamable)`<BreadcrumbWithId[]>` <Tooltip content="See BreadcrumbWithId below"/> |         |
-| `className`    | `string`                                                                                                  |         |
+| Prop           | Type                                                                                          | Default |
+| -------------- | --------------------------------------------------------------------------------------------- | ------- |
+| `breadcrumbs*` | [Streamable](/docs/soul/streamable)`<Breadcrumb[]>` <Tooltip content="See Breadcrumb below"/> |         |
+| `className`    | `string`                                                                                      |         |
 
-### BreadcrumbWithId
+### Breadcrumb
 
 | Prop    | Type     | Default |
 | ------- | -------- | ------- |
-| `id`    | `string` |         |
 | `label` | `string` |         |
 | `href`  | `string` |         |
 

--- a/apps/web/vibes/soul/docs/featured-blog-post-carousel.mdx
+++ b/apps/web/vibes/soul/docs/featured-blog-post-carousel.mdx
@@ -50,15 +50,15 @@ const posts = [
 
 ### FeaturedBlogPostCarouselProps
 
-| Prop             | Type                                                                                                         | Default |
-| ---------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
-| `className`      | `string`                                                                                                     |         |
-| `title*`         | `string`                                                                                                     |         |
-| `cta`            | `Link` <Tooltip content="See Link below"/>                                                                   |         |
-| `blogPosts*`     | [`Streamable`](/docs/soul/streamable)`<BlogPostWithId[]>` <Tooltip content="see BlogPostWithId type below"/> |         |
-| `scrollbarLabel` | `string`                                                                                                     |         |
-| `previousLabel`  | `string`                                                                                                     |         |
-| `nextLabel`      | `string`                                                                                                     |         |
+| Prop             | Type                                                                                             | Default |
+| ---------------- | ------------------------------------------------------------------------------------------------ | ------- |
+| `className`      | `string`                                                                                         |         |
+| `title*`         | `string`                                                                                         |         |
+| `cta`            | `Link` <Tooltip content="See Link below"/>                                                       |         |
+| `blogPosts*`     | [`Streamable`](/docs/soul/streamable)`<BlogPost[]>` <Tooltip content="see BlogPost type below"/> |         |
+| `scrollbarLabel` | `string`                                                                                         |         |
+| `previousLabel`  | `string`                                                                                         |         |
+| `nextLabel`      | `string`                                                                                         |         |
 
 ### Link
 
@@ -67,11 +67,10 @@ const posts = [
 | `href*`  | `string` |         |
 | `label*` | `string` |         |
 
-### BlogPostWithId
+### BlogPost
 
 | Prop       | Type                                   | Default |
 | ---------- | -------------------------------------- | ------- |
-| `id*`      | `string`                               |         |
 | `title*`   | `string`                               |         |
 | `author`   | `string  \| null`                      |
 | `content*` | `string`                               |         |

--- a/apps/web/vibes/soul/docs/featured-blog-post-list.mdx
+++ b/apps/web/vibes/soul/docs/featured-blog-post-list.mdx
@@ -74,18 +74,17 @@ const posts = [
 | `className`          | `string`                                                                                                         |         |
 | `title`              | `string`                                                                                                         |         |
 | `description`        | `string \| null`                                                                                                 |         |
-| `blogPosts*`         | [`Streamable`](docs/soul/streamable)`<BlogPostWithId[]>` <Tooltip content="See BlogPostWithId below"/>           |         |
+| `blogPosts*`         | [`Streamable`](docs/soul/streamable)`<BlogPost[]>` <Tooltip content="See BlogPost below"/>                       |         |
 | `paginationInfo`     | [`Streamable`](docs/soul/streamable)`<CursorPaginationInfo>` <Tooltip content="See CursorPaginationInfo below"/> |         |
-| `breadcrumbs`        | [`Streamable`](docs/soul/streamable)`<BreadcrumbWithId[]>` <Tooltip content="See BreadcrumbWithId below"/>       |         |
+| `breadcrumbs`        | [`Streamable`](docs/soul/streamable)`<Breadcrumb>` <Tooltip content="See Breadcrumb below"/>                     |         |
 | `emptyStateSubtitle` | [`Streamable`](docs/soul/streamable)`<string>`                                                                   |         |
 | `emptyStateTitle`    | [`Streamable`](docs/soul/streamable)`<string>`                                                                   |         |
 | `placeholderCount`   | `number`                                                                                                         |         |
 
-### BlogPostWithId
+### BlogPost
 
 | Prop       | Type                                   | Default |
 | ---------- | -------------------------------------- | ------- |
-| `id*`      | `string`                               |         |
 | `title*`   | `string`                               |         |
 | `author`   | `string  \| null`                      |
 | `content*` | `string`                               |         |
@@ -102,11 +101,10 @@ const posts = [
 | `endCursorParamName`   | `string`         |         |
 | `endCursor*`           | `string \| null` |         |
 
-### BreadcrumbWithId
+### Breadcrumb
 
 | Prop    | Type     | Default |
 | ------- | -------- | ------- |
-| `id`    | `string` |         |
 | `label` | `string` |         |
 | `href`  | `string` |         |
 

--- a/apps/web/vibes/soul/docs/featured-product-list.mdx
+++ b/apps/web/vibes/soul/docs/featured-product-list.mdx
@@ -52,18 +52,18 @@ const products = [
 
 ### FeaturedProductList
 
-| Prop                 | Type                                                                                                         | Default |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- |
-| `className`          | `string`                                                                                                     |         |
-| `title*`             | `string`                                                                                                     |         |
-| `description`        | `string`                                                                                                     |         |
-| `cta`                | `Link` <Tooltip content="See Link below"/>                                                                   |         |
-| `products*`          | [`Streamable`](docs/soul/streamable)`<ProductCardWithId[]>` <Tooltip content="See ProductCardWithId below"/> |         |
-| `emptyStateTitle`    | [`Streamable`](docs/soul/streamable)`<string>`                                                               |         |
-| `emptyStateSubtitle` | [`Streamable`](docs/soul/streamable)`<string>`                                                               |         |
-| `placeholderCount`   | `number`                                                                                                     |         |
+| Prop                 | Type                                                                                     | Default |
+| -------------------- | ---------------------------------------------------------------------------------------- | ------- |
+| `className`          | `string`                                                                                 |         |
+| `title*`             | `string`                                                                                 |         |
+| `description`        | `string`                                                                                 |         |
+| `cta`                | `Link` <Tooltip content="See Link below"/>                                               |         |
+| `products*`          | [`Streamable`](docs/soul/streamable)`<Product[]>` <Tooltip content="See Product below"/> |         |
+| `emptyStateTitle`    | [`Streamable`](docs/soul/streamable)`<string>`                                           |         |
+| `emptyStateSubtitle` | [`Streamable`](docs/soul/streamable)`<string>`                                           |         |
+| `placeholderCount`   | `number`                                                                                 |         |
 
-### ProductCardWithId
+### Product
 
 | Prop       | Type                           | Default |
 | ---------- | ------------------------------ | ------- |

--- a/apps/web/vibes/soul/docs/order-list.mdx
+++ b/apps/web/vibes/soul/docs/order-list.mdx
@@ -68,15 +68,15 @@ const orders = [
 
 ### Order
 
-| Prop          | Type                                                                   | Default |
-| ------------- | ---------------------------------------------------------------------- | ------- |
-| `id*`         | `string`                                                               |         |
-| `totalPrice*` | `string`                                                               |         |
-| `status*`     | `string`                                                               |         |
-| `href*`       | `string`                                                               |         |
-| `lineItems*`  | `ProductCardWithId[]` <Tooltip content="See ProductCardWithId below"/> |         |
+| Prop          | Type                                               | Default |
+| ------------- | -------------------------------------------------- | ------- |
+| `id*`         | `string`                                           |         |
+| `totalPrice*` | `string`                                           |         |
+| `status*`     | `string`                                           |         |
+| `href*`       | `string`                                           |         |
+| `lineItems*`  | `Product[]` <Tooltip content="See Product below"/> |         |
 
-### ProductCardWithId
+### Product
 
 | Prop       | Type                           | Default |
 | ---------- | ------------------------------ | ------- |

--- a/apps/web/vibes/soul/docs/product-card.mdx
+++ b/apps/web/vibes/soul/docs/product-card.mdx
@@ -34,19 +34,19 @@ function Usage() {
 
 ### ProductCardProps
 
-| Prop               | Type                                                     | Default                                                                                                       |
-| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `className`        | `string`                                                 |                                                                                                               |
-| `colorScheme`      | `'light' \| 'dark'`                                      | `'light'`                                                                                                     |
-| `aspectRatio`      | `'5:6' \| '3:4' \| '1:1'`                                | `'5:6'`                                                                                                       |
-| `showCompare`      | `boolean`                                                | `false'`                                                                                                      |
-| `imagePriority`    | `boolean`                                                | `false`                                                                                                       |
-| `imageSizes`       | `string`                                                 | `'(min-width: 80rem) 20vw, (min-width: 64rem) 25vw, (min-width: 42rem) 33vw, (min-width: 24rem) 50vw, 100vw'` |
-| `compareLabel`     | `string`                                                 |                                                                                                               |
-| `compareParamName` | `string`                                                 |                                                                                                               |
-| `product*`         | `ProductCard` <Tooltip content="See ProductCard below"/> |                                                                                                               |
+| Prop               | Type                                             | Default                                                                                                       |
+| ------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `className`        | `string`                                         |                                                                                                               |
+| `colorScheme`      | `'light' \| 'dark'`                              | `'light'`                                                                                                     |
+| `aspectRatio`      | `'5:6' \| '3:4' \| '1:1'`                        | `'5:6'`                                                                                                       |
+| `showCompare`      | `boolean`                                        | `false'`                                                                                                      |
+| `imagePriority`    | `boolean`                                        | `false`                                                                                                       |
+| `imageSizes`       | `string`                                         | `'(min-width: 80rem) 20vw, (min-width: 64rem) 25vw, (min-width: 42rem) 33vw, (min-width: 24rem) 50vw, 100vw'` |
+| `compareLabel`     | `string`                                         |                                                                                                               |
+| `compareParamName` | `string`                                         |                                                                                                               |
+| `product*`         | `Product` <Tooltip content="See Product below"/> |                                                                                                               |
 
-### ProductCard
+### Product
 
 | Prop       | Type                           | Default |
 | ---------- | ------------------------------ | ------- |

--- a/apps/web/vibes/soul/docs/product-card.mdx
+++ b/apps/web/vibes/soul/docs/product-card.mdx
@@ -34,19 +34,19 @@ function Usage() {
 
 ### ProductCardProps
 
-| Prop               | Type                                                                 | Default                                                                                                       |
-| ------------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `className`        | `string`                                                             |                                                                                                               |
-| `colorScheme`      | `'light' \| 'dark'`                                                  | `'light'`                                                                                                     |
-| `aspectRatio`      | `'5:6' \| '3:4' \| '1:1'`                                            | `'5:6'`                                                                                                       |
-| `showCompare`      | `boolean`                                                            | `false'`                                                                                                      |
-| `imagePriority`    | `boolean`                                                            | `false`                                                                                                       |
-| `imageSizes`       | `string`                                                             | `'(min-width: 80rem) 20vw, (min-width: 64rem) 25vw, (min-width: 42rem) 33vw, (min-width: 24rem) 50vw, 100vw'` |
-| `compareLabel`     | `string`                                                             |                                                                                                               |
-| `compareParamName` | `string`                                                             |                                                                                                               |
-| `product*`         | `ProductCardWithId` <Tooltip content="See ProductCardWithId below"/> |                                                                                                               |
+| Prop               | Type                                                     | Default                                                                                                       |
+| ------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `className`        | `string`                                                 |                                                                                                               |
+| `colorScheme`      | `'light' \| 'dark'`                                      | `'light'`                                                                                                     |
+| `aspectRatio`      | `'5:6' \| '3:4' \| '1:1'`                                | `'5:6'`                                                                                                       |
+| `showCompare`      | `boolean`                                                | `false'`                                                                                                      |
+| `imagePriority`    | `boolean`                                                | `false`                                                                                                       |
+| `imageSizes`       | `string`                                                 | `'(min-width: 80rem) 20vw, (min-width: 64rem) 25vw, (min-width: 42rem) 33vw, (min-width: 24rem) 50vw, 100vw'` |
+| `compareLabel`     | `string`                                                 |                                                                                                               |
+| `compareParamName` | `string`                                                 |                                                                                                               |
+| `product*`         | `ProductCard` <Tooltip content="See ProductCard below"/> |                                                                                                               |
 
-### ProductCardWithId
+### ProductCard
 
 | Prop       | Type                           | Default |
 | ---------- | ------------------------------ | ------- |

--- a/apps/web/vibes/soul/docs/product-detail.mdx
+++ b/apps/web/vibes/soul/docs/product-detail.mdx
@@ -106,7 +106,7 @@ export const product = {
 
 | Prop                        | Type                                                                                                                      | Default |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `breadcrumbs`               | [`Streamable`](/docs/soul/streamable)`<BreadcrumbWithId[]>` <Tooltip content="See BreadcrumbWithId below"/>               |         |
+| `breadcrumbs`               | [`Streamable`](/docs/soul/streamable)`<Breadcrumb[]>` <Tooltip content="See Breadcrumb below"/>                           |         |
 | `product`                   | [`Streamable`](/docs/soul/streamable)`<ProductDetailProduct \| null>` <Tooltip content="See ProductDetailProduct below"/> |         |
 | `action`                    | `ProductDetailFormAction<F>`                                                                                              |         |
 | `fields`                    | [`Streamable`](/docs/soul/streamable)`<F[]>`                                                                              |         |
@@ -207,13 +207,12 @@ export async function action(
 }
 ```
 
-### BreadcrumbWithId
+### Breadcrumb
 
 | Prop     | Type     | Default |
 | -------- | -------- | ------- |
 | `label*` | `string` |         |
 | `href*`  | `string` |         |
-| `id*`    | `string` |         |
 
 ### CSS Variables
 

--- a/apps/web/vibes/soul/docs/product-list-section.mdx
+++ b/apps/web/vibes/soul/docs/product-list-section.mdx
@@ -29,13 +29,13 @@ function Usage() {
 
 | Prop                    | Type                                                                                                              | Default      |
 | ----------------------- | ----------------------------------------------------------------------------------------------------------------- | ------------ |
-| `breadcrumbs`           | [`Streamable`](/docs/soul/streamable)`<BreadcrumbWithId[]>` <Tooltip content="See BreadcrumbWithId below"/>       | `'Products'` |
+| `breadcrumbs`           | [`Streamable`](/docs/soul/streamable)`<Breadcrumb[]>` <Tooltip content="See Breadcrumb below"/>                   | `'Products'` |
 | `title`                 | [`Streamable`](/docs/soul/streamable)`<string>`                                                                   |              |
 | `totalCount*`           | [`Streamable`](/docs/soul/streamable)`<number>`                                                                   |              |
-| `products*`             | [`Streamable`](/docs/soul/streamable)`<ProductCardWithId[]>` <Tooltip content="See ProductCardWithId below"/>     |              |
+| `products*`             | [`Streamable`](/docs/soul/streamable)`<Product[]>` <Tooltip content="See Product below"/>                         |              |
 | `filters*`              | [`Streamable`](/docs/soul/streamable)`<Filter[]>` <Tooltip content="See Filter below"/>                           |              |
 | `sortOptions*`          | [`Streamable`](/docs/soul/streamable)`<SortOption[]>` <Tooltip content="See SortOption below"/>                   |              |
-| `compareProducts`       | [`Streamable`](/docs/soul/streamable)`<ProductCardWithId[]>` <Tooltip content="See ProductCardWithId below"/>     |              |
+| `compareProducts`       | [`Streamable`](/docs/soul/streamable)`<Product[]>` <Tooltip content="See Product below"/>                         |              |
 | `paginationInfo`        | [`Streamable`](/docs/soul/streamable)`<CursorPaginationInfo>` <Tooltip content="See CursorPaginationInfo below"/> |              |
 | `compareAction`         | `ComponentProps<'form'>['action']`                                                                                |              |
 | `compareLabel`          | [`Streamable`](/docs/soul/streamable)`<string>`                                                                   |              |
@@ -52,7 +52,7 @@ function Usage() {
 | `emptyStateTitle`       | [`Streamable`](/docs/soul/streamable)`<string>`                                                                   |              |
 | `placeholderCount`      | `number`                                                                                                          |              |
 
-### ProductCardWithId
+### Product
 
 | Prop       | Type                           | Default |
 | ---------- | ------------------------------ | ------- |
@@ -65,13 +65,12 @@ function Usage() {
 | `badge`    | `string`                       |         |
 | `rating`   | `number`                       |         |
 
-### BreadcrumbWithId
+### Breadcrumb
 
 | Prop     | Type     | Default |
 | -------- | -------- | ------- |
 | `label*` | `string` |         |
 | `href*`  | `string` |         |
-| `id*`    | `string` |         |
 
 ### SortOption
 

--- a/apps/web/vibes/soul/examples/pages/blog/index.tsx
+++ b/apps/web/vibes/soul/examples/pages/blog/index.tsx
@@ -1,10 +1,12 @@
+import { ReactNode } from 'react';
+
 import { locales } from '@/vibes/soul/data/locales';
-import { action } from '@/vibes/soul/examples/sections/inline-email-form/actions';
 import { localeAction } from '@/vibes/soul/examples/primitives/navigation/actions';
 import { navigationLinks } from '@/vibes/soul/examples/primitives/navigation/electric';
 import { posts } from '@/vibes/soul/examples/sections/blog-post-list/warm';
+import { action } from '@/vibes/soul/examples/sections/inline-email-form/actions';
 import { Banner } from '@/vibes/soul/primitives/banner';
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
 import { Footer } from '@/vibes/soul/sections/footer';
@@ -39,7 +41,7 @@ const socialMediaLinks = [
   },
 ];
 
-const paymentIconsArray: React.ReactNode[] = [
+const paymentIconsArray: ReactNode[] = [
   <Visa key="Visa" />,
   <Amex key="Amex" />,
   <Mastercard key="Mastercard" />,
@@ -50,7 +52,7 @@ const paymentIconsArray: React.ReactNode[] = [
 ];
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -76,14 +78,12 @@ export default function Preview() {
         blogPosts={blogPostsPromise}
         breadcrumbs={[
           {
-            id: '1',
             label: 'Home',
-            href: '#',
+            href: '#1',
           },
           {
-            id: '2',
             label: 'Blog',
-            href: '#',
+            href: '#2',
           },
         ]}
         description="Expert Tips & Inspiration for Every Plant Lover"

--- a/apps/web/vibes/soul/examples/pages/home/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/home/electric.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 import { getProducts } from '@/vibes/soul/data';
 import { locales } from '@/vibes/soul/data/locales';
 import { localeAction } from '@/vibes/soul/examples/primitives/navigation/actions';
@@ -9,7 +11,7 @@ import { action } from '@/vibes/soul/examples/sections/inline-email-form/actions
 import { heroSlides } from '@/vibes/soul/examples/sections/slideshow/electric';
 import { Banner } from '@/vibes/soul/primitives/banner';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { Feature } from '@/vibes/soul/sections/feature';
 import { FeaturedCardCarousel } from '@/vibes/soul/sections/featured-card-carousel';
 import { FeaturedImage, FeaturedImageProps } from '@/vibes/soul/sections/featured-image';
@@ -50,7 +52,7 @@ const socialMediaLinks = [
   },
 ];
 
-const paymentIconsArray: React.ReactNode[] = [
+const paymentIconsArray: ReactNode[] = [
   <Visa key="Visa" />,
   <Amex key="Amex" />,
   <Mastercard key="Mastercard" />,
@@ -61,7 +63,7 @@ const paymentIconsArray: React.ReactNode[] = [
 ];
 
 // Featured Products
-export const newArrivals: ProductCardWithId[] = [
+export const newArrivals: Product[] = [
   {
     id: '1',
     title: 'Heart to Heart',

--- a/apps/web/vibes/soul/examples/pages/not-found/electric.tsx
+++ b/apps/web/vibes/soul/examples/pages/not-found/electric.tsx
@@ -5,7 +5,7 @@ import { logo, navigationLinks } from '@/vibes/soul/examples/primitives/navigati
 import { copyright, footerLinks } from '@/vibes/soul/examples/sections/footer/electric';
 import { Banner } from '@/vibes/soul/primitives/banner';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { Footer } from '@/vibes/soul/sections/footer';
 import {
@@ -51,7 +51,7 @@ const paymentIconsArray: React.ReactNode[] = [
 ];
 
 // Products
-export const products: ProductCardWithId[] = [
+export const products: Product[] = [
   {
     id: '1',
     title: 'Heart to Heart',

--- a/apps/web/vibes/soul/examples/pages/not-found/luxury.tsx
+++ b/apps/web/vibes/soul/examples/pages/not-found/luxury.tsx
@@ -1,11 +1,13 @@
+import { ReactNode } from 'react';
+
 import { locales } from '@/vibes/soul/data/locales';
-import { action } from '@/vibes/soul/examples/sections/inline-email-form/actions';
 import { localeAction } from '@/vibes/soul/examples/primitives/navigation/actions';
 import { logo, navigationLinks } from '@/vibes/soul/examples/primitives/navigation/luxury';
 import { copyright, footerLinks } from '@/vibes/soul/examples/sections/footer/luxury';
+import { action } from '@/vibes/soul/examples/sections/inline-email-form/actions';
 import { Banner } from '@/vibes/soul/primitives/banner';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { Footer } from '@/vibes/soul/sections/footer';
 import {
@@ -40,7 +42,7 @@ const socialMediaLinks = [
   },
 ];
 
-const paymentIconsArray: React.ReactNode[] = [
+const paymentIconsArray: ReactNode[] = [
   <Visa key="Visa" />,
   <Amex key="Amex" />,
   <Mastercard key="Mastercard" />,
@@ -51,7 +53,7 @@ const paymentIconsArray: React.ReactNode[] = [
 ];
 
 // Products
-export const products: ProductCardWithId[] = [
+export const products: Product[] = [
   {
     id: '1',
     title: 'DARYA LUG SOLE FISHERMAN',

--- a/apps/web/vibes/soul/examples/pages/not-found/warm.tsx
+++ b/apps/web/vibes/soul/examples/pages/not-found/warm.tsx
@@ -1,11 +1,11 @@
 import { locales } from '@/vibes/soul/data/locales';
-import { action } from '@/vibes/soul/examples/sections/inline-email-form/actions';
 import { localeAction } from '@/vibes/soul/examples/primitives/navigation/actions';
 import { logo, navigationLinks } from '@/vibes/soul/examples/primitives/navigation/warm';
 import { copyright, footerLinks } from '@/vibes/soul/examples/sections/footer/warm';
+import { action } from '@/vibes/soul/examples/sections/inline-email-form/actions';
 import { Banner } from '@/vibes/soul/primitives/banner';
 import { Navigation } from '@/vibes/soul/primitives/navigation';
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { FeaturedProductCarousel } from '@/vibes/soul/sections/featured-product-carousel';
 import { Footer } from '@/vibes/soul/sections/footer';
 import {
@@ -51,7 +51,7 @@ const paymentIconsArray: React.ReactNode[] = [
 ];
 
 // Products
-export const products: ProductCardWithId[] = [
+export const products: Product[] = [
   {
     id: '1',
     title: 'Product Name',

--- a/apps/web/vibes/soul/examples/sections/blog-post-carousel/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/blog-post-carousel/electric.tsx
@@ -1,9 +1,9 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { BlogPostCarousel } from '@/vibes/soul/sections/blog-post-carousel';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -19,9 +19,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '5',
     title: 'A Guide to Low-Light Houseplants',
     content:
       'Not all plants need bright sunlight to thrive. This guide highlights the best low-light houseplants, perfect for those darker corners of your home or office that need a touch of green.',
@@ -30,11 +29,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Low-Light Houseplants',
     },
     date: '2024-07-20',
-    href: '#',
+    href: '#1',
     author: 'Author Name',
   },
   {
-    id: '1',
     title: "Top 5 Indoor Plants to Purify Your Home's Air",
     content:
       'Discover the best indoor plants that not only add a touch of green to your space but also purify the air. From the resilient Snake Plant to the easy-going Spider Plant, these top picks will keep your home fresh and vibrant.',
@@ -43,11 +41,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Indoor Plants for Air Purification',
     },
     date: '2024-07-01',
-    href: '#',
+    href: '#2',
     author: 'Author Name',
   },
   {
-    id: '10',
     title: 'Seasonal Plant Care Tips: Preparing for Fall',
     content:
       "As the seasons change, so do your plants' needs. Get ready for fall with these seasonal plant care tips, including how to transition your outdoor plants indoors and what to expect during the colder months.",
@@ -56,11 +53,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Seasonal Plant Care Tips',
     },
     date: '2024-08-10',
-    href: '#',
+    href: '#3',
     author: 'Author Name',
   },
   {
-    id: '4',
     title: 'The Benefits of Having Plants in Your Home',
     content:
       'Plants do more than just beautify your home. They improve air quality, reduce stress, and even boost your mood. Explore the many benefits of indoor plants and why you should add more green to your living space.',
@@ -69,11 +65,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Benefits of Indoor Plants',
     },
     date: '2024-07-15',
-    href: '#',
+    href: '#4',
     author: 'Author Name',
   },
   {
-    id: '6',
     title: 'How to Repot Your Plants for Healthy Growth',
     content:
       'Repotting your plants is essential for maintaining their health and promoting growth. Over time, plants outgrow their pots, leading to root-bound conditions where roots are cramped and unable to absorb nutrients efficiently. This guide will walk you through the process of repotting, ensuring your plants thrive in their new home.',
@@ -82,11 +77,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Repotting Plants',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#5',
     author: 'Author Name',
   },
   {
-    id: '7',
     title: '5 Easy-Care Plants for Busy People',
     content:
       'Too busy to care for high-maintenance plants? These 5 easy-care plants are perfect for those with a hectic schedule. They require minimal attention while still bringing life to your home.',
@@ -95,11 +89,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Easy-Care Plants for Busy People',
     },
     date: '2024-07-30',
-    href: '#',
+    href: '#6',
     author: 'Author Name',
   },
   {
-    id: '8',
     title: 'Propagate & Share',
     content:
       'Propagating plants is an easy and rewarding way to multiply your favorite plants and share them with friends. Whether you’re working with succulents, herbs, or houseplants, you can start new plants from cuttings, leaves, or even water-rooting. This guide will show you how simple it is to propagate plants, making it a fun activity to spread the green love.',
@@ -108,11 +101,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Plant Propagation',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#7',
     author: 'Author Name',
   },
   {
-    id: '3',
     title: '5 Best Plants for Your Office Desk',
     content:
       "Brighten up your workspace with these 5 easy-to-care-for office plants. Whether you have a sunny window or a dimly lit corner, there's a perfect plant on this list to suit your office environment.",
@@ -121,11 +113,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Office Desk Plants',
     },
     date: '2024-07-10',
-    href: '#',
+    href: '#8',
     author: 'Author Name',
   },
   {
-    id: '9',
     title: 'How to Choose the Right Pot for Your Plant',
     content:
       "The right pot can make alls the difference in your plant's health. Learn how to select the perfect pot based on your plant's size, growth habits, and aesthetic preferences.",
@@ -134,7 +125,7 @@ export const posts: BlogPostWithId[] = [
     //   alt: 'Choosing the Right Pot for Your Plant',
     // },
     date: '2024-08-05',
-    href: '#',
+    href: '#9',
     author: 'Author Name',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/blog-post-carousel/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/blog-post-carousel/luxury.tsx
@@ -1,9 +1,9 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { BlogPostCarousel } from '@/vibes/soul/sections/blog-post-carousel';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -18,9 +18,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '1',
     title: 'Jada Square Toe Ballet Flats: A Timeless Classic',
     content:
       'Step into elegance with the Jada Square Toe Ballet Flat. Discover why this best-selling shoe is a staple for every luxury wardrobe.',
@@ -29,11 +28,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jada Square Toe Ballet Flat',
     },
     date: '2025-02-22',
-    href: '#',
+    href: '#1',
     author: 'Emma Carter',
   },
   {
-    id: '2',
     title: 'Jayla Woven Ballet Heel: Elevate Your Style',
     content:
       'A perfect mix of comfort and sophistication, the Jayla Woven Ballet Heel is making waves in the fashion world. Find out why!',
@@ -42,11 +40,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jayla Woven Ballet Heel',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Liam Davis',
   },
   {
-    id: '3',
     title: 'Jessie Ballet Flat: The Ultimate Luxury Statement',
     content:
       'Designed for those who appreciate both style and comfort, the Jessie Ballet Flat is redefining luxury footwear. Get the inside scoop!',
@@ -55,11 +52,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jessie Ballet Flat',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Sophia Wright',
   },
   {
-    id: '4',
     title: 'Leighton Soft Leather Loafer: A Must-Have Classic',
     content:
       'Soft, elegant, and built for comfort, the Leighton Soft Leather Loafer is a timeless addition to any wardrobe. Discover its luxurious appeal.',
@@ -68,11 +64,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Leighton Soft Leather Loafer',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Noah Wilson',
   },
   {
-    id: '5',
     title: 'Darya Lug Sole Fisherman: The Bold Fashion Choice',
     content:
       'The Darya Lug Sole Fisherman offers both durability and style. See why fashion lovers are embracing this bold, trendsetting footwear.',
@@ -81,7 +76,7 @@ export const posts: BlogPostWithId[] = [
       alt: 'DARYA LUG SOLE FISHERMAN',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Ava Richardson',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/blog-post-carousel/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/blog-post-carousel/warm.tsx
@@ -1,9 +1,9 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { BlogPostCarousel } from '@/vibes/soul/sections/blog-post-carousel';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -18,9 +18,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '1',
     title: 'The Perfect Mini Bar Bag for Your Next Adventure',
     content:
       'Discover the convenience and durability of the Mini Bar Bag, perfect for carrying your essentials on long cycling trips. With multiple colors available, this bag is a must-have for every rider.',
@@ -29,11 +28,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Mini Bar Bag',
     },
     date: '2025-02-21',
-    href: '#',
+    href: '#1',
     author: 'Alex Rider',
   },
   {
-    id: '2',
     title: 'Why Every Cyclist Needs a Stem Caddy',
     content:
       'A Stem Caddy is the ultimate accessory for quick access to snacks, tools, or even your phone. Find out why cyclists love this compact and stylish storage solution.',
@@ -42,11 +40,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Stem Caddy',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Jamie Lane',
   },
   {
-    id: '3',
     title: 'How the Hip Slinger Changes the Game for Riders',
     content:
       'Say goodbye to bulky backpacks! The Hip Slinger offers a sleek, comfortable way to carry your gear while riding. Learn why this bag is becoming a favorite among urban cyclists.',
@@ -55,11 +52,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Hip Slinger',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Morgan Wells',
   },
   {
-    id: '4',
     title: 'The Everyday Tote: More Than Just a Bag',
     content:
       'Stylish, functional, and durable—the Everyday Tote is perfect for riders who need a versatile bag for both cycling and daily life. Check out its top features.',
@@ -68,11 +64,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Everyday Tote',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Taylor Smith',
   },
   {
-    id: '5',
     title: 'Mini Saddlebag: A Compact Essential for Every Ride',
     content:
       'Whether you’re a commuter or a long-distance rider, the Mini Saddlebag keeps your tools and small essentials safe and accessible. See why riders love it.',
@@ -81,7 +76,7 @@ export const posts: BlogPostWithId[] = [
       alt: 'Mini Saddlebag',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Jordan Lee',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/blog-post-list/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/blog-post-list/electric.tsx
@@ -1,9 +1,9 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -14,9 +14,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '5',
     title: 'A Guide to Low-Light Houseplants',
     content:
       'Not all plants need bright sunlight to thrive. This guide highlights the best low-light houseplants, perfect for those darker corners of your home or office that need a touch of green.',
@@ -25,11 +24,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Low-Light Houseplants',
     },
     date: '2024-07-20',
-    href: '#',
+    href: '#1',
     author: 'Author Name',
   },
   {
-    id: '1',
     title: "Top 5 Indoor Plants to Purify Your Home's Air",
     content:
       'Discover the best indoor plants that not only add a touch of green to your space but also purify the air. From the resilient Snake Plant to the easy-going Spider Plant, these top picks will keep your home fresh and vibrant.',
@@ -38,11 +36,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Indoor Plants for Air Purification',
     },
     date: '2024-07-01',
-    href: '#',
+    href: '#2',
     author: 'Author Name',
   },
   {
-    id: '10',
     title: 'Seasonal Plant Care Tips: Preparing for Fall',
     content:
       "As the seasons change, so do your plants' needs. Get ready for fall with these seasonal plant care tips, including how to transition your outdoor plants indoors and what to expect during the colder months.",
@@ -51,11 +48,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Seasonal Plant Care Tips',
     },
     date: '2024-08-10',
-    href: '#',
+    href: '#3',
     author: 'Author Name',
   },
   {
-    id: '4',
     title: 'The Benefits of Having Plants in Your Home',
     content:
       'Plants do more than just beautify your home. They improve air quality, reduce stress, and even boost your mood. Explore the many benefits of indoor plants and why you should add more green to your living space.',
@@ -64,11 +60,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Benefits of Indoor Plants',
     },
     date: '2024-07-15',
-    href: '#',
+    href: '#4',
     author: 'Author Name',
   },
   {
-    id: '6',
     title: 'How to Repot Your Plants for Healthy Growth',
     content:
       'Repotting your plants is essential for maintaining their health and promoting growth. Over time, plants outgrow their pots, leading to root-bound conditions where roots are cramped and unable to absorb nutrients efficiently. This guide will walk you through the process of repotting, ensuring your plants thrive in their new home.',
@@ -77,11 +72,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Repotting Plants',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#5',
     author: 'Author Name',
   },
   {
-    id: '7',
     title: '5 Easy-Care Plants for Busy People',
     content:
       'Too busy to care for high-maintenance plants? These 5 easy-care plants are perfect for those with a hectic schedule. They require minimal attention while still bringing life to your home.',
@@ -90,11 +84,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Easy-Care Plants for Busy People',
     },
     date: '2024-07-30',
-    href: '#',
+    href: '#6',
     author: 'Author Name',
   },
   {
-    id: '8',
     title: 'Propagate & Share',
     content:
       'Propagating plants is an easy and rewarding way to multiply your favorite plants and share them with friends. Whether you’re working with succulents, herbs, or houseplants, you can start new plants from cuttings, leaves, or even water-rooting. This guide will show you how simple it is to propagate plants, making it a fun activity to spread the green love.',
@@ -103,11 +96,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Plant Propagation',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#7',
     author: 'Author Name',
   },
   {
-    id: '3',
     title: '5 Best Plants for Your Office Desk',
     content:
       "Brighten up your workspace with these 5 easy-to-care-for office plants. Whether you have a sunny window or a dimly lit corner, there's a perfect plant on this list to suit your office environment.",
@@ -116,11 +108,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Office Desk Plants',
     },
     date: '2024-07-10',
-    href: '#',
+    href: '#8',
     author: 'Author Name',
   },
   {
-    id: '9',
     title: 'How to Choose the Right Pot for Your Plant',
     content:
       "The right pot can make alls the difference in your plant's health. Learn how to select the perfect pot based on your plant's size, growth habits, and aesthetic preferences.",
@@ -129,7 +120,7 @@ export const posts: BlogPostWithId[] = [
     //   alt: 'Choosing the Right Pot for Your Plant',
     // },
     date: '2024-08-05',
-    href: '#',
+    href: '#9',
     author: 'Author Name',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/blog-post-list/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/blog-post-list/luxury.tsx
@@ -1,9 +1,9 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -14,9 +14,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '1',
     title: 'Jada Square Toe Ballet Flats: A Timeless Classic',
     content:
       'Step into elegance with the Jada Square Toe Ballet Flat. Discover why this best-selling shoe is a staple for every luxury wardrobe.',
@@ -25,11 +24,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jada Square Toe Ballet Flat',
     },
     date: '2025-02-22',
-    href: '#',
+    href: '#1',
     author: 'Emma Carter',
   },
   {
-    id: '2',
     title: 'Jayla Woven Ballet Heel: Elevate Your Style',
     content:
       'A perfect mix of comfort and sophistication, the Jayla Woven Ballet Heel is making waves in the fashion world. Find out why!',
@@ -38,11 +36,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jayla Woven Ballet Heel',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Liam Davis',
   },
   {
-    id: '3',
     title: 'Jessie Ballet Flat: The Ultimate Luxury Statement',
     content:
       'Designed for those who appreciate both style and comfort, the Jessie Ballet Flat is redefining luxury footwear. Get the inside scoop!',
@@ -51,11 +48,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jessie Ballet Flat',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Sophia Wright',
   },
   {
-    id: '4',
     title: 'Leighton Soft Leather Loafer: A Must-Have Classic',
     content:
       'Soft, elegant, and built for comfort, the Leighton Soft Leather Loafer is a timeless addition to any wardrobe. Discover its luxurious appeal.',
@@ -64,11 +60,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Leighton Soft Leather Loafer',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Noah Wilson',
   },
   {
-    id: '5',
     title: 'Darya Lug Sole Fisherman: The Bold Fashion Choice',
     content:
       'The Darya Lug Sole Fisherman offers both durability and style. See why fashion lovers are embracing this bold, trendsetting footwear.',
@@ -77,7 +72,7 @@ export const posts: BlogPostWithId[] = [
       alt: 'DARYA LUG SOLE FISHERMAN',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Ava Richardson',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/blog-post-list/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/blog-post-list/warm.tsx
@@ -1,9 +1,9 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -14,9 +14,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '1',
     title: 'The Perfect Mini Bar Bag for Your Next Adventure',
     content:
       'Discover the convenience and durability of the Mini Bar Bag, perfect for carrying your essentials on long cycling trips. With multiple colors available, this bag is a must-have for every rider.',
@@ -25,11 +24,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Mini Bar Bag',
     },
     date: '2025-02-21',
-    href: '#',
+    href: '#1',
     author: 'Alex Rider',
   },
   {
-    id: '2',
     title: 'Why Every Cyclist Needs a Stem Caddy',
     content:
       'A Stem Caddy is the ultimate accessory for quick access to snacks, tools, or even your phone. Find out why cyclists love this compact and stylish storage solution.',
@@ -38,11 +36,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Stem Caddy',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Jamie Lane',
   },
   {
-    id: '3',
     title: 'How the Hip Slinger Changes the Game for Riders',
     content:
       'Say goodbye to bulky backpacks! The Hip Slinger offers a sleek, comfortable way to carry your gear while riding. Learn why this bag is becoming a favorite among urban cyclists.',
@@ -51,11 +48,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Hip Slinger',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Morgan Wells',
   },
   {
-    id: '4',
     title: 'The Everyday Tote: More Than Just a Bag',
     content:
       'Stylish, functional, and durable—the Everyday Tote is perfect for riders who need a versatile bag for both cycling and daily life. Check out its top features.',
@@ -64,11 +60,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Everyday Tote',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Taylor Smith',
   },
   {
-    id: '5',
     title: 'Mini Saddlebag: A Compact Essential for Every Ride',
     content:
       'Whether you’re a commuter or a long-distance rider, the Mini Saddlebag keeps your tools and small essentials safe and accessible. See why riders love it.',
@@ -77,7 +72,7 @@ export const posts: BlogPostWithId[] = [
       alt: 'Mini Saddlebag',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Jordan Lee',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/breadcrumbs/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/breadcrumbs/electric.tsx
@@ -1,8 +1,8 @@
-import { Breadcrumbs, BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb, Breadcrumbs } from '@/vibes/soul/sections/breadcrumbs';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const breadcrumbsPromise = new Promise<BreadcrumbWithId[]>((resolve) => {
+  const breadcrumbsPromise = new Promise<Breadcrumb[]>((resolve) => {
     setTimeout(() => resolve(breadcrumbs), 1000);
   });
 
@@ -13,20 +13,17 @@ export default function Preview() {
   );
 }
 
-export const breadcrumbs: BreadcrumbWithId[] = [
+export const breadcrumbs: Breadcrumb[] = [
   {
-    id: '1',
     label: 'Home',
-    href: '#',
+    href: '#1',
   },
   {
-    id: '2',
     label: 'Plants',
-    href: '#',
+    href: '#2',
   },
   {
-    id: '3',
     label: 'Indoor',
-    href: '#',
+    href: '#3',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/breadcrumbs/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/breadcrumbs/luxury.tsx
@@ -1,8 +1,8 @@
-import { Breadcrumbs, BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb, Breadcrumbs } from '@/vibes/soul/sections/breadcrumbs';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const breadcrumbsPromise = new Promise<BreadcrumbWithId[]>((resolve) => {
+  const breadcrumbsPromise = new Promise<Breadcrumb[]>((resolve) => {
     setTimeout(() => resolve(breadcrumbs), 1000);
   });
 
@@ -13,20 +13,17 @@ export default function Preview() {
   );
 }
 
-export const breadcrumbs: BreadcrumbWithId[] = [
+export const breadcrumbs: Breadcrumb[] = [
   {
-    id: '1',
     label: 'Home',
-    href: '#',
+    href: '#1',
   },
   {
-    id: '2',
     label: 'Shoes',
-    href: '#',
+    href: '#2',
   },
   {
-    id: '3',
     label: 'Flats',
-    href: '#',
+    href: '#3',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/breadcrumbs/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/breadcrumbs/warm.tsx
@@ -1,8 +1,8 @@
-import { Breadcrumbs, BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb, Breadcrumbs } from '@/vibes/soul/sections/breadcrumbs';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export default function Preview() {
-  const breadcrumbsPromise = new Promise<BreadcrumbWithId[]>((resolve) => {
+  const breadcrumbsPromise = new Promise<Breadcrumb[]>((resolve) => {
     setTimeout(() => resolve(breadcrumbs), 1000);
   });
 
@@ -13,20 +13,17 @@ export default function Preview() {
   );
 }
 
-export const breadcrumbs: BreadcrumbWithId[] = [
+export const breadcrumbs: Breadcrumb[] = [
   {
-    id: '1',
     label: 'Home',
-    href: '#',
+    href: '#1',
   },
   {
-    id: '2',
     label: 'Bags',
-    href: '#',
+    href: '#2',
   },
   {
-    id: '3',
     label: 'Handle Bags',
-    href: '#',
+    href: '#3',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/compare-section/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/compare-section/electric.tsx
@@ -1,9 +1,8 @@
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { CompareSection } from '@/vibes/soul/sections/compare-section';
 
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
-
 export default function Preview() {
-  const products = new Promise<ProductCardWithId[]>((resolve) => {
+  const products = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(defaultProducts), 1000);
   });
 
@@ -25,7 +24,7 @@ export async function addToCartAction(id: string) {
   console.log('Add to cart:', id);
 }
 
-const defaultProducts: ProductCardWithId[] = [
+const defaultProducts: Product[] = [
   {
     id: '1',
     title: 'Philodendron Imperial Red',

--- a/apps/web/vibes/soul/examples/sections/compare-section/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/compare-section/luxury.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { CompareSection } from '@/vibes/soul/sections/compare-section';
 
 export default function Preview() {
-  const products = new Promise<ProductCardWithId[]>((resolve) => {
+  const products = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(defaultProducts), 1000);
   });
 
@@ -23,7 +23,7 @@ export async function addToCartAction(id: string) {
   console.log('Add to cart:', id);
 }
 
-const defaultProducts: ProductCardWithId[] = [
+const defaultProducts: Product[] = [
   {
     id: '1',
     title: 'Jada Square Toe Ballet Flat',

--- a/apps/web/vibes/soul/examples/sections/compare-section/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/compare-section/warm.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { Product } from '@/vibes/soul/primitives/product-card';
 import { CompareSection } from '@/vibes/soul/sections/compare-section';
 
 export default function Preview() {
-  const products = new Promise<ProductCardWithId[]>((resolve) => {
+  const products = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(defaultProducts), 1000);
   });
 
@@ -24,7 +24,7 @@ export async function addToCartAction(id: string) {
   console.log('Add to cart:', id);
 }
 
-const defaultProducts: ProductCardWithId[] = [
+const defaultProducts: Product[] = [
   {
     id: '1',
     title: 'Mini Bar Bag',

--- a/apps/web/vibes/soul/examples/sections/featured-blog-post-carousel/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-blog-post-carousel/electric.tsx
@@ -1,8 +1,8 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { FeaturedBlogPostCarousel } from '@/vibes/soul/sections/featured-blog-post-carousel';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(blogPosts), 1000);
   });
 
@@ -15,9 +15,8 @@ export default function Preview() {
   );
 }
 
-const blogPosts: BlogPostWithId[] = [
+const blogPosts: BlogPost[] = [
   {
-    id: '5',
     title: 'A Guide to Low-Light Houseplants',
     content:
       'Not all plants need bright sunlight to thrive. This guide highlights the best low-light houseplants, perfect for those darker corners of your home or office that need a touch of green.',
@@ -26,11 +25,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Low-Light Houseplants',
     },
     date: '2024-07-20',
-    href: '#',
+    href: '#1',
     author: 'Author Name',
   },
   {
-    id: '1',
     title: "Top 5 Indoor Plants to Purify Your Home's Air",
     content:
       'Discover the best indoor plants that not only add a touch of green to your space but also purify the air. From the resilient Snake Plant to the easy-going Spider Plant, these top picks will keep your home fresh and vibrant.',
@@ -39,11 +37,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Indoor Plants for Air Purification',
     },
     date: '2024-07-01',
-    href: '#',
+    href: '#2',
     author: 'Author Name',
   },
   {
-    id: '10',
     title: 'Seasonal Plant Care Tips: Preparing for Fall',
     content:
       "As the seasons change, so do your plants' needs. Get ready for fall with these seasonal plant care tips, including how to transition your outdoor plants indoors and what to expect during the colder months.",
@@ -52,11 +49,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Seasonal Plant Care Tips',
     },
     date: '2024-08-10',
-    href: '#',
+    href: '#3',
     author: 'Author Name',
   },
   {
-    id: '4',
     title: 'The Benefits of Having Plants in Your Home',
     content:
       'Plants do more than just beautify your home. They improve air quality, reduce stress, and even boost your mood. Explore the many benefits of indoor plants and why you should add more green to your living space.',
@@ -65,11 +61,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Benefits of Indoor Plants',
     },
     date: '2024-07-15',
-    href: '#',
+    href: '#3',
     author: 'Author Name',
   },
   {
-    id: '6',
     title: 'How to Repot Your Plants for Healthy Growth',
     content:
       'Repotting your plants is essential for maintaining their health and promoting growth. Over time, plants outgrow their pots, leading to root-bound conditions where roots are cramped and unable to absorb nutrients efficiently. This guide will walk you through the process of repotting, ensuring your plants thrive in their new home.',
@@ -78,11 +73,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Repotting Plants',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#4',
     author: 'Author Name',
   },
   {
-    id: '7',
     title: '5 Easy-Care Plants for Busy People',
     content:
       'Too busy to care for high-maintenance plants? These 5 easy-care plants are perfect for those with a hectic schedule. They require minimal attention while still bringing life to your home.',
@@ -91,11 +85,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Easy-Care Plants for Busy People',
     },
     date: '2024-07-30',
-    href: '#',
+    href: '#5',
     author: 'Author Name',
   },
   {
-    id: '8',
     title: 'Propagate & Share',
     content:
       'Propagating plants is an easy and rewarding way to multiply your favorite plants and share them with friends. Whether you’re working with succulents, herbs, or houseplants, you can start new plants from cuttings, leaves, or even water-rooting. This guide will show you how simple it is to propagate plants, making it a fun activity to spread the green love.',
@@ -104,11 +97,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Plant Propagation',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#6',
     author: 'Author Name',
   },
   {
-    id: '3',
     title: '5 Best Plants for Your Office Desk',
     content:
       "Brighten up your workspace with these 5 easy-to-care-for office plants. Whether you have a sunny window or a dimly lit corner, there's a perfect plant on this list to suit your office environment.",
@@ -117,11 +109,10 @@ const blogPosts: BlogPostWithId[] = [
       alt: 'Office Desk Plants',
     },
     date: '2024-07-10',
-    href: '#',
+    href: '#7',
     author: 'Author Name',
   },
   {
-    id: '9',
     title: 'How to Choose the Right Pot for Your Plant',
     content:
       "The right pot can make alls the difference in your plant's health. Learn how to select the perfect pot based on your plant's size, growth habits, and aesthetic preferences.",
@@ -130,7 +121,7 @@ const blogPosts: BlogPostWithId[] = [
     //   alt: 'Choosing the Right Pot for Your Plant',
     // },
     date: '2024-08-05',
-    href: '#',
+    href: '#8',
     author: 'Author Name',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/featured-blog-post-carousel/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-blog-post-carousel/luxury.tsx
@@ -1,8 +1,8 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { FeaturedBlogPostCarousel } from '@/vibes/soul/sections/featured-blog-post-carousel';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(blogPosts), 1000);
   });
 
@@ -15,9 +15,8 @@ export default function Preview() {
   );
 }
 
-export const blogPosts: BlogPostWithId[] = [
+export const blogPosts: BlogPost[] = [
   {
-    id: '1',
     title: 'Jada Square Toe Ballet Flats: A Timeless Classic',
     content:
       'Step into elegance with the Jada Square Toe Ballet Flat. Discover why this best-selling shoe is a staple for every luxury wardrobe.',
@@ -26,11 +25,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Jada Square Toe Ballet Flat',
     },
     date: '2025-02-22',
-    href: '#',
+    href: '#1',
     author: 'Emma Carter',
   },
   {
-    id: '2',
     title: 'Jayla Woven Ballet Heel: Elevate Your Style',
     content:
       'A perfect mix of comfort and sophistication, the Jayla Woven Ballet Heel is making waves in the fashion world. Find out why!',
@@ -39,11 +37,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Jayla Woven Ballet Heel',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Liam Davis',
   },
   {
-    id: '3',
     title: 'Jessie Ballet Flat: The Ultimate Luxury Statement',
     content:
       'Designed for those who appreciate both style and comfort, the Jessie Ballet Flat is redefining luxury footwear. Get the inside scoop!',
@@ -52,11 +49,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Jessie Ballet Flat',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Sophia Wright',
   },
   {
-    id: '4',
     title: 'Leighton Soft Leather Loafer: A Must-Have Classic',
     content:
       'Soft, elegant, and built for comfort, the Leighton Soft Leather Loafer is a timeless addition to any wardrobe. Discover its luxurious appeal.',
@@ -65,11 +61,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Leighton Soft Leather Loafer',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Noah Wilson',
   },
   {
-    id: '5',
     title: 'Darya Lug Sole Fisherman: The Bold Fashion Choice',
     content:
       'The Darya Lug Sole Fisherman offers both durability and style. See why fashion lovers are embracing this bold, trendsetting footwear.',
@@ -78,7 +73,7 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'DARYA LUG SOLE FISHERMAN',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Ava Richardson',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/featured-blog-post-carousel/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-blog-post-carousel/warm.tsx
@@ -1,8 +1,8 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { FeaturedBlogPostCarousel } from '@/vibes/soul/sections/featured-blog-post-carousel';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(blogPosts), 1000);
   });
 
@@ -15,9 +15,8 @@ export default function Preview() {
   );
 }
 
-export const blogPosts: BlogPostWithId[] = [
+export const blogPosts: BlogPost[] = [
   {
-    id: '1',
     title: 'The Perfect Mini Bar Bag for Your Next Adventure',
     content:
       'Discover the convenience and durability of the Mini Bar Bag, perfect for carrying your essentials on long cycling trips. With multiple colors available, this bag is a must-have for every rider.',
@@ -26,11 +25,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Mini Bar Bag',
     },
     date: '2025-02-21',
-    href: '#',
+    href: '#1',
     author: 'Alex Rider',
   },
   {
-    id: '2',
     title: 'Why Every Cyclist Needs a Stem Caddy',
     content:
       'A Stem Caddy is the ultimate accessory for quick access to snacks, tools, or even your phone. Find out why cyclists love this compact and stylish storage solution.',
@@ -39,11 +37,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Stem Caddy',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Jamie Lane',
   },
   {
-    id: '3',
     title: 'How the Hip Slinger Changes the Game for Riders',
     content:
       'Say goodbye to bulky backpacks! The Hip Slinger offers a sleek, comfortable way to carry your gear while riding. Learn why this bag is becoming a favorite among urban cyclists.',
@@ -52,11 +49,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Hip Slinger',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Morgan Wells',
   },
   {
-    id: '4',
     title: 'The Everyday Tote: More Than Just a Bag',
     content:
       'Stylish, functional, and durable—the Everyday Tote is perfect for riders who need a versatile bag for both cycling and daily life. Check out its top features.',
@@ -65,11 +61,10 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Everyday Tote',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Taylor Smith',
   },
   {
-    id: '5',
     title: 'Mini Saddlebag: A Compact Essential for Every Ride',
     content:
       'Whether you’re a commuter or a long-distance rider, the Mini Saddlebag keeps your tools and small essentials safe and accessible. See why riders love it.',
@@ -78,7 +73,7 @@ export const blogPosts: BlogPostWithId[] = [
       alt: 'Mini Saddlebag',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Jordan Lee',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/featured-blog-post-list/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-blog-post-list/electric.tsx
@@ -1,8 +1,8 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -11,12 +11,10 @@ export default function Preview() {
       blogPosts={blogPostsPromise}
       breadcrumbs={[
         {
-          id: '1',
           label: 'Home',
           href: '#',
         },
         {
-          id: '2',
           label: 'Blog',
           href: '#',
         },
@@ -34,9 +32,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '5',
     title: 'A Guide to Low-Light Houseplants',
     content:
       'Not all plants need bright sunlight to thrive. This guide highlights the best low-light houseplants, perfect for those darker corners of your home or office that need a touch of green.',
@@ -45,11 +42,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Low-Light Houseplants',
     },
     date: '2024-07-20',
-    href: '#',
+    href: '#1',
     author: 'Author Name',
   },
   {
-    id: '1',
     title: "Top 5 Indoor Plants to Purify Your Home's Air",
     content:
       'Discover the best indoor plants that not only add a touch of green to your space but also purify the air. From the resilient Snake Plant to the easy-going Spider Plant, these top picks will keep your home fresh and vibrant.',
@@ -58,11 +54,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Indoor Plants for Air Purification',
     },
     date: '2024-07-01',
-    href: '#',
+    href: '#2',
     author: 'Author Name',
   },
   {
-    id: '10',
     title: 'Seasonal Plant Care Tips: Preparing for Fall',
     content:
       "As the seasons change, so do your plants' needs. Get ready for fall with these seasonal plant care tips, including how to transition your outdoor plants indoors and what to expect during the colder months.",
@@ -71,11 +66,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Seasonal Plant Care Tips',
     },
     date: '2024-08-10',
-    href: '#',
+    href: '#3',
     author: 'Author Name',
   },
   {
-    id: '4',
     title: 'The Benefits of Having Plants in Your Home',
     content:
       'Plants do more than just beautify your home. They improve air quality, reduce stress, and even boost your mood. Explore the many benefits of indoor plants and why you should add more green to your living space.',
@@ -84,11 +78,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Benefits of Indoor Plants',
     },
     date: '2024-07-15',
-    href: '#',
+    href: '#4',
     author: 'Author Name',
   },
   {
-    id: '6',
     title: 'How to Repot Your Plants for Healthy Growth',
     content:
       'Repotting your plants is essential for maintaining their health and promoting growth. Over time, plants outgrow their pots, leading to root-bound conditions where roots are cramped and unable to absorb nutrients efficiently. This guide will walk you through the process of repotting, ensuring your plants thrive in their new home.',
@@ -97,11 +90,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Repotting Plants',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#5',
     author: 'Author Name',
   },
   {
-    id: '7',
     title: '5 Easy-Care Plants for Busy People',
     content:
       'Too busy to care for high-maintenance plants? These 5 easy-care plants are perfect for those with a hectic schedule. They require minimal attention while still bringing life to your home.',
@@ -110,11 +102,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Easy-Care Plants for Busy People',
     },
     date: '2024-07-30',
-    href: '#',
+    href: '#6',
     author: 'Author Name',
   },
   {
-    id: '8',
     title: 'Propagate & Share',
     content:
       'Propagating plants is an easy and rewarding way to multiply your favorite plants and share them with friends. Whether you’re working with succulents, herbs, or houseplants, you can start new plants from cuttings, leaves, or even water-rooting. This guide will show you how simple it is to propagate plants, making it a fun activity to spread the green love.',
@@ -123,11 +114,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Plant Propagation',
     },
     date: '2024-08-20',
-    href: '#',
+    href: '#7',
     author: 'Author Name',
   },
   {
-    id: '3',
     title: '5 Best Plants for Your Office Desk',
     content:
       "Brighten up your workspace with these 5 easy-to-care-for office plants. Whether you have a sunny window or a dimly lit corner, there's a perfect plant on this list to suit your office environment.",
@@ -136,11 +126,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Office Desk Plants',
     },
     date: '2024-07-10',
-    href: '#',
+    href: '#8',
     author: 'Author Name',
   },
   {
-    id: '9',
     title: 'How to Choose the Right Pot for Your Plant',
     content:
       "The right pot can make alls the difference in your plant's health. Learn how to select the perfect pot based on your plant's size, growth habits, and aesthetic preferences.",
@@ -149,7 +138,7 @@ export const posts: BlogPostWithId[] = [
     //   alt: 'Choosing the Right Pot for Your Plant',
     // },
     date: '2024-08-05',
-    href: '#',
+    href: '#9',
     author: 'Author Name',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/featured-blog-post-list/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-blog-post-list/luxury.tsx
@@ -1,8 +1,8 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -11,12 +11,10 @@ export default function Preview() {
       blogPosts={blogPostsPromise}
       breadcrumbs={[
         {
-          id: '1',
           label: 'Home',
           href: '#',
         },
         {
-          id: '2',
           label: 'Blog',
           href: '#',
         },
@@ -34,9 +32,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '1',
     title: 'Jada Square Toe Ballet Flats: A Timeless Classic',
     content:
       'Step into elegance with the Jada Square Toe Ballet Flat. Discover why this best-selling shoe is a staple for every luxury wardrobe.',
@@ -45,11 +42,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jada Square Toe Ballet Flat',
     },
     date: '2025-02-22',
-    href: '#',
+    href: '#1',
     author: 'Emma Carter',
   },
   {
-    id: '2',
     title: 'Jayla Woven Ballet Heel: Elevate Your Style',
     content:
       'A perfect mix of comfort and sophistication, the Jayla Woven Ballet Heel is making waves in the fashion world. Find out why!',
@@ -58,11 +54,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jayla Woven Ballet Heel',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Liam Davis',
   },
   {
-    id: '3',
     title: 'Jessie Ballet Flat: The Ultimate Luxury Statement',
     content:
       'Designed for those who appreciate both style and comfort, the Jessie Ballet Flat is redefining luxury footwear. Get the inside scoop!',
@@ -71,11 +66,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Jessie Ballet Flat',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Sophia Wright',
   },
   {
-    id: '4',
     title: 'Leighton Soft Leather Loafer: A Must-Have Classic',
     content:
       'Soft, elegant, and built for comfort, the Leighton Soft Leather Loafer is a timeless addition to any wardrobe. Discover its luxurious appeal.',
@@ -84,11 +78,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Leighton Soft Leather Loafer',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Noah Wilson',
   },
   {
-    id: '5',
     title: 'Darya Lug Sole Fisherman: The Bold Fashion Choice',
     content:
       'The Darya Lug Sole Fisherman offers both durability and style. See why fashion lovers are embracing this bold, trendsetting footwear.',
@@ -97,7 +90,7 @@ export const posts: BlogPostWithId[] = [
       alt: 'DARYA LUG SOLE FISHERMAN',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Ava Richardson',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/featured-blog-post-list/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-blog-post-list/warm.tsx
@@ -1,8 +1,8 @@
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { FeaturedBlogPostList } from '@/vibes/soul/sections/featured-blog-post-list';
 
 export default function Preview() {
-  const blogPostsPromise = new Promise<BlogPostWithId[]>((resolve) => {
+  const blogPostsPromise = new Promise<BlogPost[]>((resolve) => {
     setTimeout(() => resolve(posts), 1000);
   });
 
@@ -11,12 +11,10 @@ export default function Preview() {
       blogPosts={blogPostsPromise}
       breadcrumbs={[
         {
-          id: '1',
           label: 'Home',
           href: '#',
         },
         {
-          id: '2',
           label: 'Blog',
           href: '#',
         },
@@ -34,9 +32,8 @@ export default function Preview() {
   );
 }
 
-export const posts: BlogPostWithId[] = [
+export const posts: BlogPost[] = [
   {
-    id: '1',
     title: 'The Perfect Mini Bar Bag for Your Next Adventure',
     content:
       'Discover the convenience and durability of the Mini Bar Bag, perfect for carrying your essentials on long cycling trips. With multiple colors available, this bag is a must-have for every rider.',
@@ -45,11 +42,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Mini Bar Bag',
     },
     date: '2025-02-21',
-    href: '#',
+    href: '#1',
     author: 'Alex Rider',
   },
   {
-    id: '2',
     title: 'Why Every Cyclist Needs a Stem Caddy',
     content:
       'A Stem Caddy is the ultimate accessory for quick access to snacks, tools, or even your phone. Find out why cyclists love this compact and stylish storage solution.',
@@ -58,11 +54,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Stem Caddy',
     },
     date: '2025-02-18',
-    href: '#',
+    href: '#2',
     author: 'Jamie Lane',
   },
   {
-    id: '3',
     title: 'How the Hip Slinger Changes the Game for Riders',
     content:
       'Say goodbye to bulky backpacks! The Hip Slinger offers a sleek, comfortable way to carry your gear while riding. Learn why this bag is becoming a favorite among urban cyclists.',
@@ -71,11 +66,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Hip Slinger',
     },
     date: '2025-02-15',
-    href: '#',
+    href: '#3',
     author: 'Morgan Wells',
   },
   {
-    id: '4',
     title: 'The Everyday Tote: More Than Just a Bag',
     content:
       'Stylish, functional, and durable—the Everyday Tote is perfect for riders who need a versatile bag for both cycling and daily life. Check out its top features.',
@@ -84,11 +78,10 @@ export const posts: BlogPostWithId[] = [
       alt: 'Everyday Tote',
     },
     date: '2025-02-10',
-    href: '#',
+    href: '#4',
     author: 'Taylor Smith',
   },
   {
-    id: '5',
     title: 'Mini Saddlebag: A Compact Essential for Every Ride',
     content:
       'Whether you’re a commuter or a long-distance rider, the Mini Saddlebag keeps your tools and small essentials safe and accessible. See why riders love it.',
@@ -97,7 +90,7 @@ export const posts: BlogPostWithId[] = [
       alt: 'Mini Saddlebag',
     },
     date: '2025-02-05',
-    href: '#',
+    href: '#5',
     author: 'Jordan Lee',
   },
 ];

--- a/apps/web/vibes/soul/examples/sections/featured-product-list/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-product-list/electric.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { FeaturedProductList } from '@/vibes/soul/sections/featured-product-list';
 
 export default function Preview() {
-  const productsPromise = new Promise<ProductCardWithId[]>((resolve) => {
+  const productsPromise = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(products), 1000);
   });
 
@@ -19,7 +19,7 @@ export default function Preview() {
   );
 }
 
-const products: ProductCardWithId[] = [
+const products: Product[] = [
   {
     id: '1',
     title: 'Philodendron Imperial Red',

--- a/apps/web/vibes/soul/examples/sections/featured-product-list/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-product-list/luxury.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { FeaturedProductList } from '@/vibes/soul/sections/featured-product-list';
 
 export default function Preview() {
-  const productsPromise = new Promise<ProductCardWithId[]>((resolve) => {
+  const productsPromise = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(products), 1000);
   });
 
@@ -19,7 +19,7 @@ export default function Preview() {
   );
 }
 
-const products: ProductCardWithId[] = [
+const products: Product[] = [
   {
     id: '1',
     title: 'Jada Square Toe Ballet Flat',

--- a/apps/web/vibes/soul/examples/sections/featured-product-list/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/featured-product-list/warm.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { FeaturedProductList } from '@/vibes/soul/sections/featured-product-list';
 
 export default function Preview() {
-  const productsPromise = new Promise<ProductCardWithId[]>((resolve) => {
+  const productsPromise = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(products), 1000);
   });
 
@@ -19,7 +19,7 @@ export default function Preview() {
   );
 }
 
-const products: ProductCardWithId[] = [
+const products: Product[] = [
   {
     id: '1',
     title: 'Mini Bar Bag',

--- a/apps/web/vibes/soul/examples/sections/product-detail/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/product-detail/electric.tsx
@@ -1,7 +1,7 @@
 import { breadcrumbs } from '@/vibes/soul/examples/sections/breadcrumbs/electric';
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { Price } from '@/vibes/soul/primitives/price-label';
-import { BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductDetail } from '@/vibes/soul/sections/product-detail';
 import { Field } from '@/vibes/soul/sections/product-detail/schema';
 
@@ -70,7 +70,7 @@ export const product = {
 };
 
 export default function Preview() {
-  const breadcrumbsPromise = new Promise<BreadcrumbWithId[]>((resolve) => {
+  const breadcrumbsPromise = new Promise<Breadcrumb[]>((resolve) => {
     setTimeout(() => resolve(breadcrumbs), 1000);
   });
 

--- a/apps/web/vibes/soul/examples/sections/product-detail/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/product-detail/luxury.tsx
@@ -1,7 +1,7 @@
 import { breadcrumbs } from '@/vibes/soul/examples/sections/breadcrumbs/electric';
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { Price } from '@/vibes/soul/primitives/price-label';
-import { BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductDetail } from '@/vibes/soul/sections/product-detail';
 import { Field } from '@/vibes/soul/sections/product-detail/schema';
 
@@ -129,7 +129,7 @@ export const product = {
 };
 
 export default function Preview() {
-  const breadcrumbsPromise = new Promise<BreadcrumbWithId[]>((resolve) => {
+  const breadcrumbsPromise = new Promise<Breadcrumb[]>((resolve) => {
     setTimeout(() => resolve(breadcrumbs), 1000);
   });
 

--- a/apps/web/vibes/soul/examples/sections/product-detail/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/product-detail/warm.tsx
@@ -1,7 +1,7 @@
 import { breadcrumbs } from '@/vibes/soul/examples/sections/breadcrumbs/warm';
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { Price } from '@/vibes/soul/primitives/price-label';
-import { BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductDetail } from '@/vibes/soul/sections/product-detail';
 import { Field } from '@/vibes/soul/sections/product-detail/schema';
 
@@ -103,7 +103,7 @@ export const product = {
 };
 
 export default function Preview() {
-  const breadcrumbsPromise = new Promise<BreadcrumbWithId[]>((resolve) => {
+  const breadcrumbsPromise = new Promise<Breadcrumb[]>((resolve) => {
     setTimeout(() => resolve(breadcrumbs), 1000);
   });
 

--- a/apps/web/vibes/soul/examples/sections/product-list/electric.tsx
+++ b/apps/web/vibes/soul/examples/sections/product-list/electric.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { ProductList } from '@/vibes/soul/sections/product-list';
 
 export default function Preview() {
-  const products = new Promise<ProductCardWithId[]>((resolve) => {
+  const products = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(defaultProducts), 1000);
   });
 
@@ -13,7 +13,7 @@ export default function Preview() {
   );
 }
 
-const defaultProducts: ProductCardWithId[] = [
+const defaultProducts: Product[] = [
   {
     id: '1',
     title: 'Philodendron Imperial Red',

--- a/apps/web/vibes/soul/examples/sections/product-list/luxury.tsx
+++ b/apps/web/vibes/soul/examples/sections/product-list/luxury.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { ProductList } from '@/vibes/soul/sections/product-list';
 
 export default function Preview() {
-  const products = new Promise<ProductCardWithId[]>((resolve) => {
+  const products = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(defaultProducts), 1000);
   });
 
@@ -13,7 +13,7 @@ export default function Preview() {
   );
 }
 
-const defaultProducts: ProductCardWithId[] = [
+const defaultProducts: Product[] = [
   {
     id: '1',
     title: 'Jada Square Toe Ballet Flat',

--- a/apps/web/vibes/soul/examples/sections/product-list/warm.tsx
+++ b/apps/web/vibes/soul/examples/sections/product-list/warm.tsx
@@ -1,8 +1,8 @@
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { ProductList } from '@/vibes/soul/sections/product-list';
 
 export default function Preview() {
-  const products = new Promise<ProductCardWithId[]>((resolve) => {
+  const products = new Promise<Product[]>((resolve) => {
     setTimeout(() => resolve(defaultProducts), 1000);
   });
 
@@ -13,7 +13,7 @@ export default function Preview() {
   );
 }
 
-const defaultProducts: ProductCardWithId[] = [
+const defaultProducts: Product[] = [
   {
     id: '1',
     title: 'Mini Bar Bag',

--- a/apps/web/vibes/soul/primitives/blog-post-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/blog-post-card/index.tsx
@@ -16,10 +16,6 @@ export interface BlogPost {
   href: string;
 }
 
-export interface BlogPostWithId extends BlogPost {
-  id: string;
-}
-
 export interface BlogPostCardProps extends BlogPost {
   className?: string;
 }

--- a/apps/web/vibes/soul/primitives/compare-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/index.tsx
@@ -2,14 +2,14 @@ import { clsx } from 'clsx';
 
 import { Button } from '@/vibes/soul/primitives/button';
 import {
+  type Product,
   ProductCard,
   ProductCardSkeleton,
-  ProductCardWithId,
 } from '@/vibes/soul/primitives/product-card';
 import { Rating } from '@/vibes/soul/primitives/rating';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
-export interface CompareCardWithId extends ProductCardWithId {
+export interface CompareCardWithId extends Product {
   description?: string;
   customFields?: Array<{ name: string; value: string }>;
 }

--- a/apps/web/vibes/soul/primitives/product-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/product-card/index.tsx
@@ -8,7 +8,7 @@ import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 import { Compare } from './compare';
 
-export interface ProductCardWithId {
+export interface Product {
   id: string;
   title: string;
   href: string;
@@ -28,7 +28,7 @@ export interface ProductCardProps {
   imageSizes?: string;
   compareLabel?: string;
   compareParamName?: string;
-  product: ProductCardWithId;
+  product: Product;
 }
 
 /**

--- a/apps/web/vibes/soul/sections/blog-post-carousel/index.tsx
+++ b/apps/web/vibes/soul/sections/blog-post-carousel/index.tsx
@@ -3,9 +3,9 @@ import { ArrowLeft, ArrowRight } from 'lucide-react';
 
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import {
+  type BlogPost,
   BlogPostCard,
   BlogPostCardSkeleton,
-  BlogPostWithId,
 } from '@/vibes/soul/primitives/blog-post-card';
 import {
   Carousel,
@@ -18,7 +18,7 @@ import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 export interface BlogPostCarouselProps {
   className?: string;
-  blogPosts: Streamable<BlogPostWithId[]>;
+  blogPosts: Streamable<BlogPost[]>;
   scrollbarLabel?: string;
   previousLabel?: string;
   nextLabel?: string;
@@ -68,11 +68,11 @@ export function BlogPostCarousel({
         return (
           <Carousel className={clsx(className)} hideOverflow={hideOverflow}>
             <CarouselContent className="mb-10">
-              {blogPosts.map(({ id, ...post }) => {
+              {blogPosts.map(({ ...post }) => {
                 return (
                   <CarouselItem
                     className="basis-full @md:basis-1/2 @4xl:basis-1/3 @7xl:basis-1/4"
-                    key={id}
+                    key={post.href}
                   >
                     <BlogPostCard {...post} />
                   </CarouselItem>

--- a/apps/web/vibes/soul/sections/blog-post-content/index.tsx
+++ b/apps/web/vibes/soul/sections/blog-post-content/index.tsx
@@ -5,9 +5,9 @@ import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { ButtonLink } from '@/vibes/soul/primitives/button-link';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import {
+  type Breadcrumb,
   Breadcrumbs,
   BreadcrumbsSkeleton,
-  BreadcrumbWithId,
 } from '@/vibes/soul/sections/breadcrumbs';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
@@ -35,7 +35,7 @@ export interface BlogPost {
 
 export interface BlogPostContentProps {
   blogPost: Streamable<BlogPost>;
-  breadcrumbs?: Streamable<BreadcrumbWithId[]>;
+  breadcrumbs?: Streamable<Breadcrumb[]>;
   className?: string;
 }
 

--- a/apps/web/vibes/soul/sections/blog-post-list/index.tsx
+++ b/apps/web/vibes/soul/sections/blog-post-list/index.tsx
@@ -2,14 +2,14 @@ import { clsx } from 'clsx';
 
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import {
+  type BlogPost,
   BlogPostCard,
   BlogPostCardSkeleton,
-  BlogPostWithId,
 } from '@/vibes/soul/primitives/blog-post-card';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 export interface BlogPostListProps {
-  blogPosts: Streamable<BlogPostWithId[]>;
+  blogPosts: Streamable<BlogPost[]>;
   className?: string;
   emptyStateSubtitle?: Streamable<string>;
   emptyStateTitle?: Streamable<string>;
@@ -56,8 +56,8 @@ export function BlogPostList({
         return (
           <div className={clsx('@container', className)}>
             <div className="mx-auto grid grid-cols-1 gap-x-5 gap-y-8 @md:grid-cols-2 @xl:gap-y-10 @3xl:grid-cols-3">
-              {blogPosts.map(({ id, ...props }) => (
-                <BlogPostCard key={id} {...props} />
+              {blogPosts.map(({ ...post }) => (
+                <BlogPostCard key={post.href} {...post} />
               ))}
             </div>
           </div>

--- a/apps/web/vibes/soul/sections/breadcrumbs/index.tsx
+++ b/apps/web/vibes/soul/sections/breadcrumbs/index.tsx
@@ -10,12 +10,8 @@ export interface Breadcrumb {
   href: string;
 }
 
-export interface BreadcrumbWithId extends Breadcrumb {
-  id: string;
-}
-
 export interface BreadcrumbsProps {
-  breadcrumbs: Streamable<BreadcrumbWithId[]>;
+  breadcrumbs: Streamable<Breadcrumb[]>;
   className?: string;
 }
 
@@ -44,10 +40,10 @@ export function Breadcrumbs({ breadcrumbs: streamableBreadcrumbs, className }: B
         return (
           <nav aria-label="breadcrumb" className={clsx(className)}>
             <ol className="flex flex-wrap items-center gap-x-1.5 text-sm @xl:text-base">
-              {breadcrumbs.map(({ label, href }, idx) => {
-                if (idx < breadcrumbs.length - 1) {
+              {breadcrumbs.map(({ label, href }, index) => {
+                if (index < breadcrumbs.length - 1) {
                   return (
-                    <li className="inline-flex items-center gap-x-1.5" key={idx}>
+                    <li className="inline-flex items-center gap-x-1.5" key={href}>
                       <AnimatedLink
                         className="font-[family-name:var(--breadcrumbs-font-family,var(--font-family-body))] text-[var(--breadcrumbs-primary-text,hsl(var(--foreground)))] [background:linear-gradient(0deg,var(--breadcrumbs-hover,hsl(var(--primary))),var(--breadcrumbs-hover,hsl(var(--primary))))_no-repeat_left_bottom_/_0_2px]"
                         href={href}
@@ -67,7 +63,7 @@ export function Breadcrumbs({ breadcrumbs: streamableBreadcrumbs, className }: B
                 return (
                   <li
                     className="inline-flex items-center font-[family-name:var(--breadcrumbs-font-family,var(--font-family-body))] text-[var(--breadcrumbs-secondary-text,hsl(var(--contrast-500)))]"
-                    key={idx}
+                    key={href}
                   >
                     <span aria-current="page" aria-disabled="true" role="link">
                       {label}

--- a/apps/web/vibes/soul/sections/featured-blog-post-carousel/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-blog-post-carousel/index.tsx
@@ -1,6 +1,6 @@
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { AnimatedLink } from '@/vibes/soul/primitives/animated-link';
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { BlogPostCarousel } from '@/vibes/soul/sections/blog-post-carousel';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
@@ -12,7 +12,7 @@ interface Link {
 export interface FeaturedBlogPostCarouselProps {
   title: string;
   cta?: Link;
-  blogPosts: Streamable<BlogPostWithId[]>;
+  blogPosts: Streamable<BlogPost[]>;
   scrollbarLabel?: string;
   previousLabel?: string;
   nextLabel?: string;

--- a/apps/web/vibes/soul/sections/featured-blog-post-list/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-blog-post-list/index.tsx
@@ -1,16 +1,16 @@
 import { Streamable } from '@/vibes/soul/lib/streamable';
-import { BlogPostWithId } from '@/vibes/soul/primitives/blog-post-card';
+import { type BlogPost } from '@/vibes/soul/primitives/blog-post-card';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import { BlogPostList } from '@/vibes/soul/sections/blog-post-list';
-import { Breadcrumbs, BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb, Breadcrumbs } from '@/vibes/soul/sections/breadcrumbs';
 import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 
 export interface FeaturedBlogPostListProps {
   title: string;
   description?: string | null;
-  blogPosts: Streamable<BlogPostWithId[]>;
+  blogPosts: Streamable<BlogPost[]>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
-  breadcrumbs?: Streamable<BreadcrumbWithId[]>;
+  breadcrumbs?: Streamable<Breadcrumb[]>;
   emptyStateSubtitle?: Streamable<string>;
   emptyStateTitle?: Streamable<string>;
   placeholderCount?: number;

--- a/apps/web/vibes/soul/sections/featured-product-list/index.tsx
+++ b/apps/web/vibes/soul/sections/featured-product-list/index.tsx
@@ -1,6 +1,6 @@
 import { Streamable } from '@/vibes/soul/lib/streamable';
 import { ButtonLink } from '@/vibes/soul/primitives/button-link';
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import { ProductList } from '@/vibes/soul/sections/product-list';
 import { StickySidebarLayout } from '@/vibes/soul/sections/sticky-sidebar-layout';
 
@@ -13,7 +13,7 @@ export interface FeaturedProductsListProps {
   title: string;
   description?: string;
   cta?: Link;
-  products: Streamable<ProductCardWithId[]>;
+  products: Streamable<Product[]>;
   emptyStateTitle?: Streamable<string>;
   emptyStateSubtitle?: Streamable<string>;
   placeholderCount?: number;

--- a/apps/web/vibes/soul/sections/order-list/index.tsx
+++ b/apps/web/vibes/soul/sections/order-list/index.tsx
@@ -5,9 +5,9 @@ import { Badge } from '@/vibes/soul/primitives/badge';
 import { ButtonLink } from '@/vibes/soul/primitives/button-link';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
 import {
+  type Product,
   ProductCard,
   ProductCardSkeleton,
-  ProductCardWithId,
 } from '@/vibes/soul/primitives/product-card';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
@@ -16,7 +16,7 @@ export interface Order {
   totalPrice: string;
   status: string;
   href: string;
-  lineItems: ProductCardWithId[];
+  lineItems: Product[];
 }
 
 export interface OrderListProps {

--- a/apps/web/vibes/soul/sections/product-carousel/index.tsx
+++ b/apps/web/vibes/soul/sections/product-carousel/index.tsx
@@ -10,13 +10,13 @@ import {
   CarouselScrollbar,
 } from '@/vibes/soul/primitives/carousel';
 import {
+  type Product,
   ProductCard,
   ProductCardSkeleton,
-  ProductCardWithId,
 } from '@/vibes/soul/primitives/product-card';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
-export type CarouselProduct = ProductCardWithId;
+export type CarouselProduct = Product;
 
 export interface ProductCarouselProps {
   products: Streamable<CarouselProduct[]>;

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -5,7 +5,7 @@ import { Accordion, AccordionItem } from '@/vibes/soul/primitives/accordion';
 import { Price, PriceLabel } from '@/vibes/soul/primitives/price-label';
 import { Rating } from '@/vibes/soul/primitives/rating';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
-import { Breadcrumbs, BreadcrumbWithId } from '@/vibes/soul/sections/breadcrumbs';
+import { type Breadcrumb, Breadcrumbs } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductGallery } from '@/vibes/soul/sections/product-detail/product-gallery';
 
 import { ProductDetailForm, ProductDetailFormAction } from './product-detail-form';
@@ -31,7 +31,7 @@ interface ProductDetailProduct {
 }
 
 export interface ProductDetailProps<F extends Field> {
-  breadcrumbs?: Streamable<BreadcrumbWithId[]>;
+  breadcrumbs?: Streamable<Breadcrumb[]>;
   product: Streamable<ProductDetailProduct | null>;
   action: ProductDetailFormAction<F>;
   fields: Streamable<F[]>;

--- a/apps/web/vibes/soul/sections/product-list-section/index.tsx
+++ b/apps/web/vibes/soul/sections/product-list-section/index.tsx
@@ -4,13 +4,13 @@ import { ComponentProps } from 'react';
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { Button } from '@/vibes/soul/primitives/button';
 import { CursorPagination, CursorPaginationInfo } from '@/vibes/soul/primitives/cursor-pagination';
-import { ProductCardWithId } from '@/vibes/soul/primitives/product-card';
+import { type Product } from '@/vibes/soul/primitives/product-card';
 import * as SidePanel from '@/vibes/soul/primitives/side-panel';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 import {
+  type Breadcrumb,
   Breadcrumbs,
   BreadcrumbsSkeleton,
-  BreadcrumbWithId,
 } from '@/vibes/soul/sections/breadcrumbs';
 import { ProductList } from '@/vibes/soul/sections/product-list';
 import { Filter, FilterPanel } from '@/vibes/soul/sections/product-list-section/filter-panel';
@@ -21,13 +21,13 @@ import {
 } from '@/vibes/soul/sections/product-list-section/sorting';
 
 export interface ProductListSectionProps {
-  breadcrumbs?: Streamable<BreadcrumbWithId[]>;
+  breadcrumbs?: Streamable<Breadcrumb[]>;
   title?: Streamable<string>;
   totalCount: Streamable<number>;
-  products: Streamable<ProductCardWithId[]>;
+  products: Streamable<Product[]>;
   filters: Streamable<Filter[]>;
   sortOptions: Streamable<SortOption[]>;
-  compareProducts?: Streamable<ProductCardWithId[]>;
+  compareProducts?: Streamable<Product[]>;
   paginationInfo?: Streamable<CursorPaginationInfo>;
   compareAction?: ComponentProps<'form'>['action'];
   compareLabel?: Streamable<string>;

--- a/apps/web/vibes/soul/sections/product-list/index.tsx
+++ b/apps/web/vibes/soul/sections/product-list/index.tsx
@@ -4,15 +4,15 @@ import { ComponentProps } from 'react';
 import { Stream, Streamable } from '@/vibes/soul/lib/streamable';
 import { CompareDrawer } from '@/vibes/soul/primitives/compare-drawer';
 import {
+  type Product,
   ProductCard,
   ProductCardSkeleton,
-  ProductCardWithId,
 } from '@/vibes/soul/primitives/product-card';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
 
 interface ProductListProps {
-  products: Streamable<ProductCardWithId[]>;
-  compareProducts?: Streamable<ProductCardWithId[]>;
+  products: Streamable<Product[]>;
+  compareProducts?: Streamable<Product[]>;
   className?: string;
   colorScheme?: 'light' | 'dark';
   aspectRatio?: '5:6' | '3:4' | '1:1';


### PR DESCRIPTION
## What / Why
- simplifies types by removing the `WithId` naming convention

There's more to be done, but this PR completes on: 
- `BlogPostWithId` -> `BlogPost`
- `ProductCardWithId` -> `Product`
- `BreadcrumbWithId` -> `Breadcrumb`

For example, `ProductCardWithId` was renamed to just `Product`. Components that did not need an id, like Breadcrumbs and BlogPosts had `id` removed and used `href` as their key instead.