### PR TITLE
fix: homepage mobile CTAs

### DIFF
--- a/apps/web/app/(marketing)/page.tsx
+++ b/apps/web/app/(marketing)/page.tsx
@@ -5,7 +5,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { ReactNode, useEffect, useState } from 'react';
 
-import { Button } from '@/components/ui/button';
 import { ButtonLink } from '@/components/ui/button-link';
 import Transition from '@/components/ui/transition';
 import { Arrow } from '@/icons/generated';
@@ -233,12 +232,11 @@ export default function Home() {
             to="translate-y-0 opacity-100"
           >
             <div className="mb-4 mt-6 flex items-center gap-1.5 sm:hidden">
-              <ScrollButton to="footer">
-                <Button size="large">Get updates</Button>
-              </ScrollButton>
-
               <ButtonLink href="/contribute" size="large">
                 Contribute
+              </ButtonLink>
+              <ButtonLink href="/docs/soul" size="large">
+                Docs
               </ButtonLink>
             </div>
           </Transition>

--- a/apps/web/components/navigation/chapter-select.tsx
+++ b/apps/web/components/navigation/chapter-select.tsx
@@ -27,7 +27,8 @@ const comingSoonChapters = [
       name: 'Tinloof',
       url: 'https://tinloof.com',
     },
-    description: 'A 2px vibe.',
+    description:
+      'A bold design that combines brutalist and minimal styles, featuring distinctive 2-pixel borders and details.',
     thumbnail: '/2px/thumbnail.png',
     tags: ['Ecommerce'],
   },

--- a/apps/web/vibes/soul/index.ts
+++ b/apps/web/vibes/soul/index.ts
@@ -11,7 +11,7 @@ export default {
   slug: 'soul',
   tags: ['Ecommerce'],
   description: `A minimalistic modern ecommerce theme inspired by Nike, Lululemon and other leading apparel brands.`,
-  thumbnail: 'https://rstr.in/monogram/vibes/O7uLelHbgdn',
+  thumbnail: '/soul/soul-introduction.webp',
   author: {
     name: 'Monogram',
     url: 'https://monogram.io',


### PR DESCRIPTION
## What / Why
- adds correct CTA to docs on mobile
- replaces SOUL preview image in vibe selector drawer