### PR TITLE
fix: set search param for compare redirect as 'ids'

### DIFF
--- a/apps/web/vibes/soul/primitives/compare-drawer/index.tsx
+++ b/apps/web/vibes/soul/primitives/compare-drawer/index.tsx
@@ -205,7 +205,7 @@ export function CompareDrawer({
             </div>
             <ButtonLink
               className="hidden @md:block"
-              href={`${href}?${paramName}=${params?.toString()}`}
+              href={`${href}?$ids=${params?.toString()}`}
               size="medium"
               variant="primary"
             >


### PR DESCRIPTION
Since the most common `href` for a compare page is `compare` and the default search param is `compare`, it looks weird to redirect to `/compare?compare=1,2,3`. This defaults the search param in the redirect link to `ids`, which is what it passes.