### PR TITLE
fix: missing prose class and max-width prose override

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -158,7 +158,7 @@ export function ProductDetail<F extends Field>({
                     <Stream fallback={<ProductDescriptionSkeleton />} value={product.description}>
                       {(description) =>
                         Boolean(description) && (
-                          <div className="border-t border-[var(--product-detail-border,hsl(var(--contrast-100)))] py-8 text-[var(--product-detail-secondary-text,hsl(var(--contrast-500)))]">
+                          <div className="prose prose-sm max-w-none border-t border-[var(--product-detail-border,hsl(var(--contrast-100)))] py-8">
                             {description}
                           </div>
                         )


### PR DESCRIPTION
## What / Why
- adds prose class to `ProductDetails` description to support custom HTML
- removes the default `max-width` set by my prose

## Testing
https://github.com/user-attachments/assets/3736fec4-ae89-4441-9b46-207dbae3d632

