### PR TITLE
remove: refresh data cache to pdp form?

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/product-detail-form.tsx
@@ -100,12 +100,8 @@ export function ProductDetailForm<F extends Field>({
   useEffect(() => {
     if (lastResult?.status === 'success') {
       toast.success(successMessage);
-
-      // This is needed to refresh the Data Cache after the product has been added to the cart.
-      // The cart id is not picked up after the first time the cart is created/updated.
-      router.refresh();
     }
-  }, [lastResult, successMessage, router]);
+  }, [lastResult, successMessage]);
 
   const [form, formFields] = useForm({
     lastResult,


### PR DESCRIPTION
## What / Why
- removes `router.refresh()` from the PDP form since it's specific to Catalyst