### PR TITLE
Hunter/vib 4122 update installation page in vibes

### DIFF
--- a/apps/web/vibes/soul/docs/electric.mdx
+++ b/apps/web/vibes/soul/docs/electric.mdx
@@ -11,6 +11,7 @@ title: 'Electric'
       name: 'DM Serif Text',
       options: { display: 'swap', subsets: ['latin'], weight: '400' },
     },
+    mono: { type: 'google', name: 'Roboto Mono', options: { display: 'swap', subsets: ['latin'] } },
   }}
 />
 
@@ -18,8 +19,13 @@ title: 'Electric'
 
 ## Typography
 
-<BrandTypography brandName="Electric" />
-
 ### Font families
 
-<BrandFonts brandName="Electric" fonts={{ body: 'Epilogue', heading: 'Epilogue' }} />
+<BrandFonts
+  brandName="Electric"
+  fonts={{ body: 'Inter', heading: 'DM Serif Text', mono: 'Roboto Mono' }}
+/>
+
+### Font sizes
+
+<BrandTypography brandName="Electric" />

--- a/apps/web/vibes/soul/docs/installation.mdx
+++ b/apps/web/vibes/soul/docs/installation.mdx
@@ -4,15 +4,23 @@ title: Installation
 
 <Steps>
   <Step>
-    ### Add dependencies
+    ### Follow the [Tailwind documentation](https://v3.tailwindcss.com/docs/guides/nextjs) to create a new Next.js project using Tailwind 3.
 
-    ```bash
-    npm install -D tailwindcss-animate @tailwindcss/container-queries
-    ```
+    Currently, Soul supports Tailwind v3, so be sure to follow the documentation above to ensure you're using Tailwind v3.
 
   </Step>
+
+  <Step>
+    ### Install dependencies
+
+    <CodeBlock lang='bash' children='npm install -D @tailwindcss/container-queries @tailwindcss/typography tailwindcss-animate' />
+
+  </Step>
+
   <Step>
     ### Update `tailwind.config.ts`
+
+    You may need to update your `tailwind.config.js` file from a `js` file to a `ts` file.
 
     <TailwindConfig />
 

--- a/apps/web/vibes/soul/docs/luxury.mdx
+++ b/apps/web/vibes/soul/docs/luxury.mdx
@@ -11,6 +11,7 @@ title: 'Luxury'
       name: 'DM Serif Text',
       options: { display: 'swap', subsets: ['latin'], weight: '400' },
     },
+    mono: { type: 'google', name: 'Roboto Mono', options: { display: 'swap', subsets: ['latin'] } },
   }}
 />
 
@@ -18,8 +19,13 @@ title: 'Luxury'
 
 ## Typography
 
-<BrandTypography brandName="Luxury" />
-
 ### Font families
 
-<BrandFonts brandName="Luxury" fonts={{ body: 'Epilogue', heading: 'Epilogue' }} />
+<BrandFonts
+  brandName="Luxury"
+  fonts={{ body: 'Inter', heading: 'DM Serif Text', mono: 'Roboto Mono' }}
+/>
+
+### Font sizes
+
+<BrandTypography brandName="Luxury" />

--- a/apps/web/vibes/soul/docs/warm.mdx
+++ b/apps/web/vibes/soul/docs/warm.mdx
@@ -11,6 +11,7 @@ title: 'Warm'
       name: 'Inter',
       options: { display: 'swap', subsets: ['latin'] },
     },
+    mono: { type: 'google', name: 'Roboto Mono', options: { display: 'swap', subsets: ['latin'] } },
   }}
 />
 
@@ -18,8 +19,10 @@ title: 'Warm'
 
 ## Typography
 
-<BrandTypography brandName="Warm" />
-
 ### Font families
 
-<BrandFonts brandName="Warm" fonts={{ body: 'Epilogue', heading: 'Epilogue' }} />
+<BrandFonts brandName="Warm" fonts={{ body: 'Inter', heading: 'Inter', mono: 'Roboto Mono' }} />
+
+### Font sizes
+
+<BrandTypography brandName="Warm" />

--- a/apps/web/vibes/tailwind.config.ts
+++ b/apps/web/vibes/tailwind.config.ts
@@ -4,7 +4,14 @@ import type { Config } from 'tailwindcss';
 import animate from 'tailwindcss-animate';
 
 export default {
-  content: ['./components/**/*.{ts,tsx}', './app/**/*.{ts,tsx}', './vibes/**/*.{ts,tsx}'],
+  content: [
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './vibes/**/*.{ts,tsx}',
+
+    // Or if using `src` directory:
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
   theme: {
     extend: {
       typography: {


### PR DESCRIPTION
## What / Why
- fixes duplicate fonts being imported into example with `removeDuplicatesByName` function
- makes `getLayoutCode` function more verbose so it's easier to follow and read
- removes `// [!code highlight]` from examples because it was being copied onto the clipboard ( more details below )
- rewords instructions to be clearer
- adds option in `tailwind.config` file for those using `src` directory in their Next.js files

### removes `// [!code highlight]` from examples because it was being copied onto the clipboard

Currently, when you copy the code from examples that include highlighted lines, the transformer `// [!code highlight]` is also included. I tried to fix this by getting the code using a `ref` and `innerText`, but was having issues with the line breaks disappearing. I decided the easiest option for now is to just remove `// [!code highlight]` from the examples and try and fix this later.

## Testing
https://github.com/user-attachments/assets/6c70f1f1-d2eb-434b-a412-52ad30c8c060

