### PR TITLE
fix: allow streaming of buy button separate from options

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -216,7 +216,7 @@ function ProductGallerySkeleton() {
 }
 
 function PriceLabelSkeleton() {
-  return <Skeleton.Box className="my-4 h-4 w-20 rounded-md" />;
+  return <Skeleton.Box className="my-5 h-4 w-20 rounded-md" />;
 }
 
 function RatingSkeleton() {


### PR DESCRIPTION
In some cases, we have product options static or available before the status of the buy button, so we want to decouple these as separate loading states.