### PR TITLE
feat: add className to NotFound component

### DIFF
--- a/apps/web/vibes/soul/docs/not-found.mdx
+++ b/apps/web/vibes/soul/docs/not-found.mdx
@@ -28,10 +28,11 @@ function Usage() {
 
 ### NotFoundProps
 
-| Prop       | Type     | Default |
-| ---------- | -------- | ------- |
-| `title`    | `string` |         |
-| `subtitle` | `string` |         |
+| Prop        | Type     | Default                              |
+| ----------- | -------- | ------------------------------------ |
+| `title`     | `string` | 'Not found'                          |
+| `subtitle`  | `string` | 'Take a look around if you're lost.' |
+| `className` | `string` | ''                                   |
 
 ### CSS Variables
 

--- a/apps/web/vibes/soul/sections/not-found/index.tsx
+++ b/apps/web/vibes/soul/sections/not-found/index.tsx
@@ -3,6 +3,7 @@ import { SectionLayout } from '@/vibes/soul/sections/section-layout';
 export interface NotFoundProps {
   title?: string;
   subtitle?: string;
+  className?: string;
 }
 
 /**
@@ -21,9 +22,10 @@ export interface NotFoundProps {
 export function NotFound({
   title = 'Not found',
   subtitle = "Take a look around if you're lost.",
+  className = '',
 }: NotFoundProps) {
   return (
-    <SectionLayout containerSize="2xl">
+    <SectionLayout className={className} containerSize="2xl">
       <header className="font-[family-name:var(--not-found-font-family,var(--font-family-body))]">
         <h1 className="mb-3 font-[family-name:var(--not-found-title-font-family,var(--font-family-heading))] text-3xl font-medium leading-none text-[var(--not-found-title,hsl(var(--foreground)))] @xl:text-4xl @4xl:text-5xl">
           {title}


### PR DESCRIPTION
## What / Why
- adds `className` to `NotFound` to allow passing to `SectionLayout`

## Testing

https://github.com/user-attachments/assets/7b94eb9c-da48-450a-9bd6-720cfcd9c099


