### PR TITLE
fix: adjust spacing for price label skeleton

### DIFF
--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -216,7 +216,7 @@ function ProductGallerySkeleton() {
 }
 
 function PriceLabelSkeleton() {
-  return <Skeleton.Box className="my-4 h-4 w-20 rounded-md" />;
+  return <Skeleton.Box className="my-5 h-4 w-20 rounded-md" />;
 }
 
 function RatingSkeleton() {


### PR DESCRIPTION
Adjust spacing to prevent layout shift when the price loads.