### PR TITLE
feat: add Reveal component to CompareCard

### DIFF
--- a/apps/web/components/ui/table-of-contents.tsx
+++ b/apps/web/components/ui/table-of-contents.tsx
@@ -82,7 +82,7 @@ export function TableOfContents({ className, offsetTop = 0 }: Props) {
               href={`#${heading.id}`}
               onClick={(e) => {
                 e.preventDefault();
-                const element = document.querySelector(`#${heading.id}`);
+                const element = document.getElementById(heading.id);
 
                 window.scrollTo({
                   top: (element?.getBoundingClientRect().top ?? 0) + window.scrollY - offsetTop,

--- a/apps/web/vibes/soul/docs/compare-card.mdx
+++ b/apps/web/vibes/soul/docs/compare-card.mdx
@@ -67,13 +67,21 @@ This component uses the Next.js Image component. The `imageSizes` prop is passed
 
 This component supports various CSS variables for theming. Here's a comprehensive list.
 
-```css
+<CodeBlock lang="css">{`
 :root {
-  --compare-card-divider: hsl(var(--contrast-100));
-  --compare-card-label: hsl(var(--foreground));
-  --compare-card-description: hsl(var(--contrast-400));
-  --compare-card-field: hsl(var(--foreground));
-  --compare-card-font-family-primary: var(--font-family-body);
-  --compare-card-font-family-secondary: var(--font-family-mono);
+    --compare-card-divider: hsl(var(--contrast-100));
+    --compare-card-label: hsl(var(--foreground));
+    --compare-card-description: hsl(var(--contrast-400));
+    --compare-card-field: hsl(var(--foreground));
+    --compare-card-font-family-primary: var(--font-family-body);
+    --compare-card-font-family-secondary: var(--font-family-mono);
 }
-```
+`}</CodeBlock>
+
+## Changelog
+
+### 2025-04-29
+
+- Added `Reveal` component to handle overflow content
+- Added `prose` & `prose-sm` classes to `product.description` to handle markdown content
+- Changed `product.customFields` to render a [Description List element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl) with a grid layout

--- a/apps/web/vibes/soul/examples/primitives/compare-card/electric.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-card/electric.tsx
@@ -17,8 +17,60 @@ export default function Preview() {
           subtitle: 'Blue/Black/Green',
           price: '$44.95',
           badge: 'New',
+          description: <Description />,
+          rating: 4.5,
+          customFields,
         }}
       />
     </div>
+  );
+}
+
+const customFields = [
+  {
+    name: 'SKU',
+    value: 'RR-PLTR',
+  },
+  {
+    name: 'Weight',
+    value: '18 oz',
+  },
+  {
+    name: 'Material',
+    value: 'Clay',
+  },
+  {
+    name: 'Ceramic Features',
+    value: 'Hand-Finished, High-Fired Stoneware with Waterproof Matte Glaze',
+  },
+];
+
+function Description() {
+  return (
+    <>
+      <p>
+        Bring a touch of the tropics into your home with the stunning{' '}
+        <strong>Philodendron Imperial Red</strong>. This vibrant houseplant features broad, glossy
+        leaves that emerge a deep burgundy-red and mature to a rich, dark green, creating a striking
+        contrast in any space. Known for its easy-care nature, the Imperial Red thrives in bright,
+        indirect light and requires minimal maintenance, making it perfect for both beginners and
+        seasoned plant lovers.
+      </p>
+      <p>
+        Add a bold pop of color to your living room, office, or bedroom with this eye-catching
+        plant. Its upright, compact growth habit makes it ideal for tabletops, shelves, or as a
+        statement piece on the floor. Not only does the Philodendron Imperial Red enhance your
+        décor, but it also helps purify the air, promoting a healthier indoor environment.
+      </p>
+      <ul>
+        <li>Dramatic red and green foliage</li>
+        <li>Low-maintenance and easy to grow</li>
+        <li>Air-purifying qualities</li>
+        <li>Perfect for home or office décor</li>
+      </ul>
+      <p>
+        Brighten up your space and enjoy the lush beauty of the Philodendron Imperial Red today!
+      </p>
+    </>
   );
 }

--- a/apps/web/vibes/soul/examples/primitives/compare-card/luxury.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-card/luxury.tsx
@@ -17,8 +17,50 @@ export default function Preview() {
           subtitle: 'Black/Brown',
           price: '$350',
           badge: 'New',
+          description: <Description />,
+          rating: 4.2,
+          customFields,
         }}
       />
     </div>
+  );
+}
+
+const customFields = [
+  {
+    name: 'SKU',
+    value: 'JADA-SQ-BLK',
+  },
+  {
+    name: 'Material',
+    value: 'Premium Italian Leather',
+  },
+  {
+    name: 'Sole',
+    value: 'Flexible Rubber',
+  },
+  {
+    name: 'Features',
+    value: 'Cushioned Insole, Square Toe Design, Slip-On Style',
+  },
+];
+
+function Description() {
+  return (
+    <>
+      <p>
+        Step into effortless elegance with the <strong>Jada Square Toe Ballet Flat</strong>.
+        Designed with a modern square toe silhouette, this versatile flat combines timeless style
+        with contemporary flair. Crafted from premium materials, the Jada offers a comfortable,
+        flexible fit that moves with you throughout your day, making it perfect for both work and
+        weekend wear.
+      </p>
+      <p>
+        Whether you&apos;re dressing up for the office or keeping it casual for a day out, the Jada
+        Square Toe Ballet Flat adds a chic finishing touch to any outfit. Its cushioned insole
+        ensures all-day comfort, while the minimalist design pairs seamlessly with everything from
+        tailored trousers to your favorite jeans.
+      </p>
+    </>
   );
 }

--- a/apps/web/vibes/soul/examples/primitives/compare-card/warm.tsx
+++ b/apps/web/vibes/soul/examples/primitives/compare-card/warm.tsx
@@ -16,8 +16,49 @@ export default function Preview() {
           subtitle: 'Blue/Green',
           price: '$65',
           badge: 'New',
+          description: <Description />,
+          rating: 4.3,
+          customFields,
         }}
       />
     </div>
+  );
+}
+
+const customFields = [
+  {
+    name: 'SKU',
+    value: 'MBB-BLUE-GRN',
+  },
+  {
+    name: 'Material',
+    value: 'Premium Canvas',
+  },
+  {
+    name: 'Dimensions',
+    value: '8" x 5" x 3"',
+  },
+  {
+    name: 'Features',
+    value: 'Adjustable Strap, Secure Closure, Interior Card Slots',
+  },
+];
+
+function Description() {
+  return (
+    <>
+      <p>
+        Elevate your style with the <strong>Mini Bar Bag</strong>, a compact yet statement-making
+        accessory designed for life on the go. Featuring a sleek, structured silhouette and a
+        polished bar detail, this bag effortlessly transitions from day to night, adding a touch of
+        sophistication to any ensemble.
+      </p>
+      <p>
+        The Mini Bar Bag offers just enough space for your essentials, with a secure closure and an
+        adjustable strap for versatile carrying options. Whether you&apos;re heading to brunch, a
+        night out, or a special event, this chic mini bag is the perfect finishing touch to complete
+        your look.
+      </p>
+    </>
   );
 }

--- a/apps/web/vibes/soul/primitives.ts
+++ b/apps/web/vibes/soul/primitives.ts
@@ -70,7 +70,7 @@ export const primitives = [
   {
     name: 'compare-card',
     dependencies: ['clsx'],
-    registryDependencies: ['skeleton', 'product-card', 'rating', 'button-link'],
+    registryDependencies: ['skeleton', 'product-card', 'rating', 'button-link', 'reveal'],
     files: ['primitives/compare-card/index.tsx', 'primitives/compare-card/add-to-cart-form.tsx'],
   },
   {

--- a/apps/web/vibes/soul/primitives/compare-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/index.tsx
@@ -1,14 +1,14 @@
 import { clsx } from 'clsx';
 
+import { ButtonLink } from '@/vibes/soul/primitives/button-link';
 import {
   type Product,
   ProductCard,
   ProductCardSkeleton,
 } from '@/vibes/soul/primitives/product-card';
 import { Rating } from '@/vibes/soul/primitives/rating';
+import { Reveal } from '@/vibes/soul/primitives/reveal';
 import * as Skeleton from '@/vibes/soul/primitives/skeleton';
-
-import { ButtonLink } from '@/vibes/soul/primitives/button-link';
 
 import { AddToCartForm, CompareAddToCartAction } from './add-to-cart-form';
 
@@ -69,7 +69,7 @@ export function CompareCard({
   return (
     <div
       className={clsx(
-        'w-full max-w-md divide-y divide-[var(--compare-card-divider,hsl(var(--contrast-100)))] font-[family-name:var(--compare-card-font-family-primary,var(--font-family-body))] font-normal @container',
+        'w-full max-w-72 divide-y divide-[var(--compare-card-divider,hsl(var(--contrast-100)))] font-[family-name:var(--compare-card-font-family-primary,var(--font-family-body))] font-normal @container',
         className,
       )}
     >
@@ -108,9 +108,9 @@ export function CompareCard({
           {descriptionLabel}
         </div>
         {product.description != null && product.description !== '' ? (
-          <div className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">
-            {product.description}
-          </div>
+          <Reveal>
+            <div className="prose prose-sm">{product.description}</div>
+          </Reveal>
         ) : (
           <p className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">
             {noDescriptionLabel}
@@ -122,13 +122,18 @@ export function CompareCard({
           <div className="font-[family-name:var(--compare-card-font-family-secondary,var(--font-family-mono))] text-xs font-normal uppercase text-[var(--compare-card-label,hsl(var(--foreground)))]">
             {otherDetailsLabel}
           </div>
-          {product.customFields.map((field, index) => (
-            <div key={index}>
-              <p className="text-xs font-normal text-[var(--compare-card-field,hsl(var(--foreground)))]">
-                <strong>{field.name}</strong>: {field.value}
-              </p>
-            </div>
-          ))}
+          <Reveal>
+            <dl className="grid grid-cols-2 gap-1 text-xs font-normal text-[var(--compare-card-field,hsl(var(--foreground)))]">
+              {product.customFields.map((field, index) => (
+                <>
+                  <dt className="font-semibold" key={`name-${index}`}>
+                    {field.name}:{' '}
+                  </dt>
+                  <dd key={`value-${index}`}>{field.value}</dd>
+                </>
+              ))}
+            </dl>
+          </Reveal>
         </div>
       ) : (
         <div className="space-y-4 py-4">


### PR DESCRIPTION
## What / Why
- adds content for `product.description` & `product.customfields` to `CompareCard` examples
- adds `prose` to `CompareCard` description
- adds `Reveal` component to descriptions & custom fields
- updates `CompareCard` changelog

## Testing

https://github.com/user-attachments/assets/1d8220bd-64b7-4c52-ba40-b1367b884986

