### PR TITLE
feat: remove default margin added by prose

### DIFF
--- a/apps/web/vibes/soul/docs/compare-card.mdx
+++ b/apps/web/vibes/soul/docs/compare-card.mdx
@@ -82,6 +82,7 @@ This component supports various CSS variables for theming. Here's a comprehensiv
 
 ### 2025-04-29
 
+- Added `[&>div>*:first-child]:mt-0` to `product.description` to remove default `margin-top` added by `prose` for the first child
 - Added `Reveal` component to handle overflow content
 - Added `prose` & `prose-sm` classes to `product.description` to handle markdown content
 - Changed `product.customFields` to render a [Description List element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl) with a grid layout

--- a/apps/web/vibes/soul/primitives/compare-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/index.tsx
@@ -109,7 +109,7 @@ export function CompareCard({
         </div>
         {product.description != null && product.description !== '' ? (
           <Reveal>
-            <div className="prose prose-sm">{product.description}</div>
+            <div className="prose prose-sm [&>div>*:first-child]:mt-0">{product.description}</div>
           </Reveal>
         ) : (
           <p className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">


### PR DESCRIPTION
## What / Why
- adds styling to remove margin-top being added to first element when content is wrapped in div
- updates `CompareCard` docs