### PR TITLE
feat: add styles that remove default margins being added by prose for…

### DIFF
--- a/apps/web/vibes/soul/docs/compare-card.mdx
+++ b/apps/web/vibes/soul/docs/compare-card.mdx
@@ -80,6 +80,10 @@ This component supports various CSS variables for theming. Here's a comprehensiv
 
 ## Changelog
 
+### 2025-05-01
+
+- Added `[&>div>*:last-child]:mb-0` to `product.description` to remove default `margin-bottom` added by `prose` for the last child
+
 ### 2025-04-29
 
 - Added `[&>div>*:first-child]:mt-0` to `product.description` to remove default `margin-top` added by `prose` for the first child

--- a/apps/web/vibes/soul/docs/product-detail.mdx
+++ b/apps/web/vibes/soul/docs/product-detail.mdx
@@ -218,12 +218,19 @@ export async function action(
 
 This component supports various CSS variables for theming. Here's a comprehensive list.
 
-```css
+<CodeBlock lang="css">{`
 :root {
-  --product-detail-border: hsl(var(--contrast-100));
-  --product-detail-subtitle-font-family: var(--font-family-mono);
-  --product-detail-title-font-family: var(--font-family-heading);
-  --product-detail-primary-text: hsl(var(--foreground));
-  --product-detail-secondary-text: hsl(var(--contrast-500));
+    --product-detail-border: hsl(var(--contrast-100));
+    --product-detail-subtitle-font-family: var(--font-family-mono);
+    --product-detail-title-font-family: var(--font-family-heading);
+    --product-detail-primary-text: hsl(var(--foreground));
+    --product-detail-secondary-text: hsl(var(--contrast-500));
 }
-```
+`}</CodeBlock>
+
+## Changelog
+
+### 2025-05-01
+
+- Added `[&>div>*:last-child]:mb-0` to `product.description` to remove default `margin-bottom` added by `prose` for the last child
+- Added `[&>div>*:first-child]:mt-0` to `product.description` to remove default `margin-top` added by `prose` for the first child

--- a/apps/web/vibes/soul/primitives/compare-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/compare-card/index.tsx
@@ -110,7 +110,9 @@ export function CompareCard({
         </div>
         {product.description != null && product.description !== '' ? (
           <Reveal>
-            <div className="prose prose-sm [&>div>*:first-child]:mt-0">{product.description}</div>
+            <div className="prose prose-sm [&>div>*:first-child]:mt-0 [&>div>*:last-child]:mb-0">
+              {product.description}
+            </div>
           </Reveal>
         ) : (
           <p className="text-sm text-[var(--compare-card-description,hsl(var(--contrast-400)))]">

--- a/apps/web/vibes/soul/sections/product-detail/index.tsx
+++ b/apps/web/vibes/soul/sections/product-detail/index.tsx
@@ -158,7 +158,7 @@ export function ProductDetail<F extends Field>({
                     <Stream fallback={<ProductDescriptionSkeleton />} value={product.description}>
                       {(description) =>
                         Boolean(description) && (
-                          <div className="prose prose-sm max-w-none border-t border-[var(--product-detail-border,hsl(var(--contrast-100)))] py-8">
+                          <div className="prose prose-sm max-w-none border-t border-[var(--product-detail-border,hsl(var(--contrast-100)))] py-8 [&>div>*:first-child]:mt-0 [&>div>*:last-child]:mb-0">
                             {description}
                           </div>
                         )


### PR DESCRIPTION
## What / Why

This pull request introduces changes to improve the styling of product descriptions in the `CompareCard` and `ProductDetail` components by ensuring consistent spacing for the first and last child elements. Additionally, it updates documentation to reflect these changes and modernizes code formatting for CSS examples.

### Styling Improvements:

* [`apps/web/vibes/soul/primitives/compare-card/index.tsx`](diffhunk://#diff-909751d1e8d9ed3a5d86622d586bba559698aa17232aa344f6ac27e2f7c91308L113-R115): Added `[&>div>*:last-child]:mb-0` to the `CompareCard` component to remove the default `margin-bottom` for the last child in `product.description`.
* [`apps/web/vibes/soul/sections/product-detail/index.tsx`](diffhunk://#diff-92fd3ff83dc33e91995dcc0794da0d9ca70e1e85207417d3d3d284e09992ff23L161-R161): Updated the `ProductDetail` component to include both `[&>div>*:first-child]:mt-0` and `[&>div>*:last-child]:mb-0`, ensuring consistent spacing for the first and last child elements in `product.description`.

### Documentation Updates:

* [`apps/web/vibes/soul/docs/compare-card.mdx`](diffhunk://#diff-9af61d9d50ffb1c251781cb4509d6e2f7485d3716a09d0351b5a80bbb496d2e6R83-R86): Added a changelog entry for the `2025-05-01` update, documenting the addition of `[&>div>*:last-child]:mb-0` for `product.description`.
* [`apps/web/vibes/soul/docs/product-detail.mdx`](diffhunk://#diff-ad4b4fa35c546eb03c4237e0979dd4e73b72a7509024c438c77b81fdcdf32094L221-R236): Updated the changelog with the same `2025-05-01` entry and replaced the CSS code block with a `<CodeBlock>` component for improved formatting.

## Testing

https://github.com/user-attachments/assets/3fecafc6-2ecc-4c15-bf6d-73c9b7d98b6b

