### PR TITLE
fix: card-radio-group props in docs

### DIFF
--- a/apps/web/vibes/soul/docs/card-radio-group.mdx
+++ b/apps/web/vibes/soul/docs/card-radio-group.mdx
@@ -72,7 +72,7 @@ This component uses the RadioGroup component from Radix UI. Refer to the [RadioG
 | ---------- | ------------------------------ | ------- |
 | `value*`   | `string`                       |         |
 | `label*`   | `string`                       |         |
-| `image*`   | `{ src: string; alt: string }` |         |
+| `image`    | `{ src: string; alt: string }` |         |
 | `disabled` | `boolean`                      |         |
 
 ### CSS Variables


### PR DESCRIPTION
## What / Why
- fixes `CardRadioGroup` props in docs