### PR TITLE
fix: add missing error styles for inputs with errors

### DIFF
--- a/apps/web/vibes/soul/form/input/index.tsx
+++ b/apps/web/vibes/soul/form/input/index.tsx
@@ -21,15 +21,15 @@ export interface InputProps extends ComponentPropsWithRef<'input'> {
  *   --input-light-background: var(--background);
  *   --input-light-text: var(--foreground);
  *   --input-light-border: var(--contrast-100);
+ *   --input-light-border-error: var(--error);
  *   --input-light-focus: var(--foreground);
  *   --input-light-placeholder: var(--contrast-500);
- *   --input-light-error: var(--error);
  *   --input-dark-background: var(--foreground);
  *   --input-dark-text: var(--background);
  *   --input-dark-border: var(--contrast-500);
+ *   --input-dark-border-error: var(--error);
  *   --input-dark-focus: var(--background);
  *   --input-dark-placeholder: var(--contrast-100);
- *   --input-dark-error: var(--error);
  *  }
  * ```
  */
@@ -65,8 +65,18 @@ export const Input = ({
           'relative overflow-hidden rounded-lg border transition-colors duration-200 focus:outline-hidden',
           {
             light:
-              'border-(--input-light-border,var(--contrast-100)) bg-(--input-light-background,var(--background)) focus-within:border-(--input-light-focus,var(--foreground))',
-            dark: 'border-(--input-dark-border,var(--contrast-500)) bg-(--input-dark-background,var(--foreground)) focus-within:border-(--input-dark-focus,var(--background))',
+              'bg-(--input-light-background,var(--background)) focus-within:border-(--input-light-focus,var(--foreground))',
+            dark: 'bg-(--input-dark-background,var(--foreground)) focus-within:border-(--input-dark-focus,var(--background))',
+          }[colorScheme],
+          {
+            light:
+              errors && errors.length > 0
+                ? 'border-[var(--input-light-border-error,hsl(var(--error)))]'
+                : 'border-[var(--input-light-border,hsl(var(--contrast-100)))]',
+            dark:
+              errors && errors.length > 0
+                ? 'border-[var(--input-dark-border-error,hsl(var(--error)))]'
+                : 'border-[var(--input-dark-border,hsl(var(--contrast-500)))]',
           }[colorScheme],
         )}
       >

--- a/apps/web/vibes/soul/form/number-input/index.tsx
+++ b/apps/web/vibes/soul/form/number-input/index.tsx
@@ -21,6 +21,7 @@ import { Label } from '@/vibes/soul/form/label';
  *   --number-input-light-button-background: var(--background);
  *   --number-input-light-button-background-hover: var(--contrast-100) / 50%;
  *   --number-input-light-button-border: var(--contrast-100);
+ *   --number-input-light-button-border-error: var(--error);
  *   --number-input-dark-background: var(--background);
  *   --number-input-dark-text: var(--background);
  *   --number-input-dark-icon: var(--contrast-300);
@@ -28,6 +29,7 @@ import { Label } from '@/vibes/soul/form/label';
  *   --number-input-dark-button-background: var(--foreground);
  *   --number-input-dark-button-background-hover: var(--contrast-500) / 50%;
  *   --number-input-dark-button-border: var(--contrast-500);
+ *   --number-input-dark-button-border-error: var(--error);
  *  }
  * ```
  */
@@ -68,9 +70,18 @@ export const NumberInput = React.forwardRef<
           className={clsx(
             'inline-flex items-center rounded-lg border',
             {
+              light: 'bg-(--number-input-light-background,var(--background))',
+              dark: 'bg-(--number-input-dark-background,var(--foreground))',
+            }[colorScheme],
+            {
               light:
-                'border-(--number-input-light-button-border,var(--contrast-100)) bg-(--number-input-light-background,var(--background))',
-              dark: 'border-(--number-input-dark-button-border,var(--contrast-500)) bg-(--number-input-dark-background,var(--foreground))',
+                errors && errors.length > 0
+                  ? 'border-[var(--number-input-light-button-border-error,hsl(var(--error)))]'
+                  : 'border-[var(--number-input-light-button-border,hsl(var(--contrast-100)))]',
+              dark:
+                errors && errors.length > 0
+                  ? 'border-[var(--number-input-dark-button-border-error,hsl(var(--error)))]'
+                  : 'border-[var(--number-input-dark-button-border,hsl(var(--contrast-500)))]',
             }[colorScheme],
           )}
         >


### PR DESCRIPTION
Adds missing styles.

<img width="763" alt="Screenshot 2025-06-06 at 2 00 34 PM" src="https://github.com/user-attachments/assets/479522c7-0d9c-4080-a9dc-193f0e4023f4" />
