### PR TITLE
fix: overflow issue with shiki code blocks

### DIFF
--- a/apps/web/app/(marketing)/style/shiki.css
+++ b/apps/web/app/(marketing)/style/shiki.css
@@ -56,7 +56,7 @@
 }
 
 .shiki {
-  @apply !bg-contrast-100 !rounded-none p-4;
+  @apply !bg-contrast-100 flex !rounded-none p-4;
 }
 
 .shiki code {
@@ -68,9 +68,6 @@
 
 .shiki .line {
   @apply relative block text-sm;
-  padding: 0 var(--shiki-line-padding);
-  width: calc(100% + (var(--shiki-line-padding) * 2));
-  margin: 0 calc(-1 * var(--shiki-line-padding));
   min-height: 20px;
 }
 


### PR DESCRIPTION
## What / Why
- fixes overflow/scroll issue by setting `overflow-auto` to `<code>` and  removing unnecessary padding, margin, and width from Shiki lines
- fixes issue with one-line code snippets having a higher height than necessary by setting the Shiki container to `flex`

## Testing

### Display `flex` fix

https://github.com/user-attachments/assets/10dce1d3-21c3-4a35-a865-7ed934516505

### Overflow fix

https://github.com/user-attachments/assets/3a21dff5-c73e-4c1b-ae0c-67c822d3386c



