### PR TITLE
feat: add disabled styles for checkbox

### DIFF
--- a/apps/web/vibes/soul/docs/checkbox.mdx
+++ b/apps/web/vibes/soul/docs/checkbox.mdx
@@ -53,6 +53,9 @@ This component supports various CSS variables for theming. Here's a comprehensiv
     --checkbox-light-checked-border-hover: var(--foreground);
     --checkbox-light-checked-background: var(--foreground);
     --checkbox-light-checked-icon: var(--background);
+    --checkbox-light-disabled-border: var(--contrast-200);
+    --checkbox-light-disabled-background: var(--contrast-100);
+    --checkbox-light-disabled-icon: var(--contrast-300);
     --checkbox-dark-label: var(--background);
     --checkbox-dark-error: var(--error);
     --checkbox-dark-unchecked-border: var(--contrast-400);
@@ -63,6 +66,9 @@ This component supports various CSS variables for theming. Here's a comprehensiv
     --checkbox-dark-checked-border-hover: var(--background);
     --checkbox-dark-checked-background: var(--foreground);
     --checkbox-dark-checked-icon: var(--foreground);
+    --checkbox-dark-disabled-border: var(--contrast-200);
+    --checkbox-dark-disabled-background: var(--contrast-100);
+    --checkbox-dark-disabled-icon: var(--contrast-300);
     --checkbox-font-family: var(--font-family-body);
 }
 `}</CodeBlock>

--- a/apps/web/vibes/soul/form/checkbox/index.tsx
+++ b/apps/web/vibes/soul/form/checkbox/index.tsx
@@ -31,6 +31,9 @@ export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxP
  *    --checkbox-light-checked-border-hover: var(--foreground);
  *    --checkbox-light-checked-background: var(--foreground);
  *    --checkbox-light-checked-icon: var(--background);
+ *    --checkbox-light-disabled-border: var(--contrast-200);
+ *    --checkbox-light-disabled-background: var(--contrast-100);
+ *    --checkbox-light-disabled-icon: var(--contrast-300);
  *    --checkbox-dark-label: var(--background);
  *    --checkbox-dark-error: var(--error);
  *    --checkbox-dark-unchecked-border: var(--contrast-400);
@@ -41,6 +44,9 @@ export interface CheckboxProps extends ComponentPropsWithoutRef<typeof CheckboxP
  *    --checkbox-dark-checked-border-hover: var(--background);
  *    --checkbox-dark-checked-background: var(--foreground);
  *    --checkbox-dark-checked-icon: var(--foreground);
+ *    --checkbox-dark-disabled-border: var(--contrast-200);
+ *    --checkbox-dark-disabled-background: var(--contrast-100);
+ *    --checkbox-dark-disabled-icon: var(--contrast-300);
  *    --checkbox-font-family: var(--font-family-body);
  *  }
  * ```
@@ -67,16 +73,30 @@ export function Checkbox({
           {...props}
           aria-labelledby={id !== undefined ? `${id}-label` : `${generatedId}-label`}
           className={clsx(
-            'flex h-5 w-5 items-center justify-center rounded-md border transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-(--checkbox-focus,var(--primary)) focus-visible:outline-0',
+            'peer flex h-5 w-5 items-center justify-center rounded-md border transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-(--checkbox-focus,var(--primary)) focus-visible:outline-0 disabled:cursor-not-allowed',
             {
               light:
                 errors && errors.length > 0
                   ? 'border-(--checkbox-light-error,var(--error))'
-                  : 'data-[state=checked]:border-(--checkbox-light-checked-border,var(--foreground)) data-[state=checked]:bg-(--checkbox-light-checked-background,var(--foreground)) data-[state=checked]:text-(--checkbox-light-checked-text,var(--background)) data-[state=checked]:hover:border-(--checkbox-light-checked-border-hover,var(--foreground)) data-[state=unchecked]:border-(--checkbox-light-unchecked-border,var(--contrast-200)) data-[state=unchecked]:bg-(--checkbox-light-unchecked-background,var(--background)) data-[state=unchecked]:text-(--checkbox-light-unchecked-text,var(--foreground)) data-[state=unchecked]:hover:border-(--checkbox-light-unchecked-border-hover,var(--contrast-300))',
+                  : clsx(
+                      // Disabled states
+                      'disabled:border-(--checkbox-light-disabled-border,var(--contrast-200)) disabled:bg-(--checkbox-light-disabled-background,var(--contrast-100)) disabled:text-(--checkbox-light-disabled-icon,var(--contrast-300))',
+                      // Normal states
+                      'enabled:data-[state=checked]:border-(--checkbox-light-checked-border,var(--foreground)) enabled:data-[state=checked]:bg-(--checkbox-light-checked-background,var(--foreground)) enabled:data-[state=checked]:text-(--checkbox-light-checked-text,var(--background)) enabled:data-[state=unchecked]:border-(--checkbox-light-unchecked-border,var(--contrast-200)) enabled:data-[state=unchecked]:bg-(--checkbox-light-unchecked-background,var(--background)) enabled:data-[state=unchecked]:text-(--checkbox-light-unchecked-text,var(--foreground))',
+                      // Hover states (only apply when checkbox is enabled)
+                      'enabled:data-[state=checked]:hover:border-(--checkbox-light-checked-border-hover,var(--foreground)) enabled:data-[state=unchecked]:hover:border-(--checkbox-light-unchecked-border-hover,var(--contrast-300))',
+                    ),
               dark:
                 errors && errors.length > 0
                   ? 'border-(--checkbox-dark-error,var(--error))'
-                  : 'data-[state=checked]:border-(--checkbox-dark-checked-border,var(--background)) data-[state=checked]:bg-(--checkbox-dark-checked-background,var(--foreground)) data-[state=checked]:text-(--checkbox-dark-checked-text,var(--background)) data-[state=checked]:hover:border-(--checkbox-dark-checked-border-hover,var(--background)) data-[state=unchecked]:border-(--checkbox-dark-unchecked-border,var(--contrast-400)) data-[state=unchecked]:bg-(--checkbox-dark-unchecked-background,var(--foreground)) data-[state=unchecked]:text-(--checkbox-dark-unchecked-text,var(--background)) data-[state=unchecked]:hover:border-(--checkbox-dark-unchecked-border-hover,var(--contrast-300))',
+                  : clsx(
+                      // Disabled states
+                      'disabled:border-(--checkbox-dark-disabled-border,var(--contrast-200)) disabled:bg-(--checkbox-dark-disabled-background,var(--contrast-100)) disabled:text-(--checkbox-dark-disabled-icon,var(--contrast-300))',
+                      // Normal states
+                      'enabled:data-[state=checked]:border-(--checkbox-dark-checked-border,var(--background)) enabled:data-[state=checked]:bg-(--checkbox-dark-checked-background,var(--foreground)) enabled:data-[state=checked]:text-(--checkbox-dark-checked-text,var(--background)) enabled:data-[state=unchecked]:border-(--checkbox-dark-unchecked-border,var(--contrast-400)) enabled:data-[state=unchecked]:bg-(--checkbox-dark-unchecked-background,var(--foreground)) enabled:data-[state=unchecked]:text-(--checkbox-dark-unchecked-text,var(--background))',
+                      // Hover states (only apply when checkbox is enabled)
+                      'enabled:data-[state=checked]:hover:border-(--checkbox-dark-checked-border-hover,var(--background)) enabled:data-[state=unchecked]:hover:border-(--checkbox-dark-unchecked-border-hover,var(--contrast-300))',
+                    ),
             }[colorScheme],
           )}
           id={id ?? generatedId}
@@ -89,7 +109,7 @@ export function Checkbox({
         {label != null && label !== '' && (
           <LabelPrimitive.Root
             className={clsx(
-              'cursor-pointer text-sm',
+              'cursor-pointer text-sm peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
               {
                 light: 'text-(--checkbox-light-label,var(--foreground))',
                 dark: 'text-(--checkbox-dark-label,var(--background))',


### PR DESCRIPTION
## What/Why?
Adds Tailwind classes used to style the checkbox input and label based on the disabled state of the checkbox. 

## Testing
Default:

https://github.com/user-attachments/assets/e4fdfed8-930b-4ea5-8038-1ea71c63f6e5

Disabled:

https://github.com/user-attachments/assets/1a044ff6-1923-478e-ae36-07ca858afdf3

Checked + disabled:

https://github.com/user-attachments/assets/c17e4e3b-cecb-494b-b0eb-66ef47748159