### PR TITLE
Add `description` to `BlogPost` type

### DIFF
--- a/apps/web/vibes/soul/primitives/blog-post-card/index.tsx
+++ b/apps/web/vibes/soul/primitives/blog-post-card/index.tsx
@@ -75,7 +75,7 @@ export function BlogPostCard({
         {title}
       </h5>
       <p className="mt-1.5 line-clamp-3 text-sm font-normal text-(--blog-post-card-content-text,var(--contrast-400))">
-        {description || content}
+        {description ?? content}
       </p>
       <div className="mt-3 text-sm text-(--blog-post-card-author-date-text,var(--foreground))">
         <time dateTime={date}>


### PR DESCRIPTION
`BlogPost` type has  a `content` property that is currently being used in `BlogPostContent` and assumed to be HTML. However, it is used as a regular string in `BlogPostCard`. This PR adds an optional `description` to `BlogPost` type that can be used in `BlogPostCard` if it's available. Otherwise, it will continue to use the `content` prop.