### PR TITLE
chore: publish cli 1.0.0 to npm

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibes",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "CLI for installing VIBES components",
   "private": false,
   "publishConfig": {


### PR DESCRIPTION
## What/Why
- bumps VIBES CLI to 1.0.0