### PR TITLE
docs: add file-input installation instructions

### DIFF
--- a/apps/web/app/(marketing)/docs/[vibe]/[page]/page.tsx
+++ b/apps/web/app/(marketing)/docs/[vibe]/[page]/page.tsx
@@ -190,6 +190,7 @@ export default async function Page({
               'prose-pre:my-0 prose-pre:outline-primary',
               'prose-pre:[&_code]:block prose-pre:[&_code]:px-5 prose-pre:[&_code]:py-5 prose-pre:[&_code]:text-sm prose-pre:[&_code]:leading-5',
               'prose-table:my-0',
+              'prose-hr:border-contrast-200',
             )}
           >
             {meta.features && (

--- a/apps/web/vibes/soul/docs/changelog.mdx
+++ b/apps/web/vibes/soul/docs/changelog.mdx
@@ -11,6 +11,8 @@ We've added a new [`FileInput`](/docs/soul/file-input) component that supports d
 
 <Preview componentName="file-input-example" size="sm" />
 
+---
+
 ### Launch of VIBES CLI
 
 We're excited to announce the launch of the [VIBES CLI](https://www.npmjs.com/package/vibes) – a command-line tool for installing VIBES components directly into your project.

--- a/apps/web/vibes/soul/examples/form/file-input/index.tsx
+++ b/apps/web/vibes/soul/examples/form/file-input/index.tsx
@@ -48,16 +48,20 @@ export default function Preview() {
   );
 
   return (
-    <div className="p-10">
-      <FileInput
-        accept="image/*"
-        label="Feature Images"
-        maxFiles={2}
-        maxSize={200 * 1024}
-        message="Max 2 files, up to 200KB"
-        multiple
-        onUpload={onUpload}
-      />
+    <div className="@container">
+      <div className="p-4 @lg:p-10">
+        <div className="mx-auto max-w-xl">
+          <FileInput
+            accept="image/*"
+            label="Feature Images"
+            maxFiles={2}
+            maxSize={200 * 1024}
+            message="Max 2 files, up to 200KB"
+            multiple
+            onUpload={onUpload}
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/vibes/soul/registry/form.ts
+++ b/apps/web/vibes/soul/registry/form.ts
@@ -58,6 +58,16 @@ export const form = [
     files: ['form/field-error/index.tsx'],
   },
   {
+    name: 'file-input',
+    dependencies: ['clsx', 'lucide-react'],
+    registryDependencies: ['label', 'button', 'toaster'],
+    files: [
+      'form/file-input/index.tsx',
+      'form/file-input/file-dropzone.tsx',
+      'form/file-input/file-item.tsx',
+    ],
+  },
+  {
     name: 'form-status',
     dependencies: ['clsx', 'lucide-react'],
     registryDependencies: [],


### PR DESCRIPTION
## What/Why
- adds installation to `FileInput` docs and adds component to registry

## Testing
https://github.com/user-attachments/assets/42c49e22-cd19-4bfc-adc4-1c163b1ec006

